### PR TITLE
Fixed uxum for macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxum"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Alex Unigovsky <unik@devrandom.ru>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -58,7 +58,6 @@ hyper = {version = "1.6", features = ["http1", "http2", "server"]}
 hyper-util = {version = "0.1", features = ["http1", "http2", "server"]}
 inventory = "0.3"
 iso8601-duration = "0.2"
-libsystemd = "0.7"
 maplit = "1.0"
 mime = "0.3"
 okapi = {version = "0.7", features = ["preserve_order"]}
@@ -79,7 +78,7 @@ recloser = "1.1"
 reqwest = {version = "0.12", default-features = false, features = ["charset", "hickory-dns", "http2", "json", "macos-system-configuration", "rustls-tls-native-roots"]}
 reqwest-middleware = {version = "0.4", features = ["multipart", "json"]}
 reqwest-tracing = {version = "0.5.7", features = ["opentelemetry_0_29"]}
-rust-crypto = "0.2"
+subtle = "2.5"
 rustls = {version = "0.23", features = ["std", "aws_lc_rs", "custom-provider"]}
 schemars = {version = "0.8", features = ["bytes", "chrono", "preserve_order", "semver", "url"]}
 serde = {version = "1.0", features = ["derive"]}
@@ -101,3 +100,7 @@ url = {version = "2.5", features = ["serde"]}
 [features]
 default = []
 grpc = ["prost", "tonic"]
+systemd = ["libsystemd"]
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libsystemd = {version = "0.7", optional = true}

--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ An opinionated backend service framework based on axum.
 ## Supported crate features
 
  * `grpc`: support nesting Tonic GRPC services inside Axum server instance.
+ * `systemd`: enable systemd integration for service notifications and watchdog support (Linux only).

--- a/examples/advanced_server/Cargo.toml
+++ b/examples/advanced_server/Cargo.toml
@@ -16,7 +16,8 @@ serde = {version = "1.0", features = ["derive"]}
 thiserror = "2.0"
 tonic = "0.13"
 tonic-reflection = "0.13"
-uxum = {path = "../..", features = ["grpc"]}
+uxum = {path = "../..", features = ["grpc", "systemd"]}
+tracing = {version = "0.1", features = ["std"]}
 
 [build-dependencies]
 tonic-build = "0.13"

--- a/examples/basic_server/Cargo.toml
+++ b/examples/basic_server/Cargo.toml
@@ -11,3 +11,4 @@ publish = false
 
 [dependencies]
 uxum = { path = "../.." }
+tracing = {version = "0.1", features = ["std"]}

--- a/examples/inner_service/Cargo.toml
+++ b/examples/inner_service/Cargo.toml
@@ -14,3 +14,4 @@ axum-server = {version = "0.7", features = ["tls-rustls"]}
 serde = {version = "1.0", features = ["derive"]}
 tokio = {version = "1.44", features = ["full"]}
 uxum = { path = "../.." }
+tracing = {version = "0.1", features = ["std"]}

--- a/examples/redis-kv/Cargo.toml
+++ b/examples/redis-kv/Cargo.toml
@@ -19,3 +19,4 @@ serde = {version = "1.0", features = ["derive"]}
 thiserror = "2.0"
 uxum = {path = "../.."}
 uxum-pools = {path = "../../uxum-pools", features = ["bb8"]}
+tracing = {version = "0.1", features = ["std"]}

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -8,6 +8,7 @@ use std::{
 use argon2::{Argon2, PasswordVerifier};
 use password_hash::PasswordHashString;
 use serde::{Deserialize, Serialize};
+use subtle::ConstantTimeEq;
 
 /// User configuration.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -45,7 +46,7 @@ pub enum UserPassword {
 impl PartialEq<&str> for UserPassword {
     fn eq(&self, other: &&str) -> bool {
         match self {
-            Self::Plaintext(pwd) => crypto::util::fixed_time_eq(pwd.as_bytes(), other.as_bytes()),
+            Self::Plaintext(pwd) => pwd.as_bytes().ct_eq(other.as_bytes()).into(),
             // FIXME: generalize hash verification.
             Self::Hashed(pwd) => Argon2::default()
                 .verify_password(other.as_bytes(), &pwd.password_hash())


### PR DESCRIPTION
- Factored out systemd into a separate optional feature
- Replaced deprecated `rust-crypto` dependency (which was last updated 9 years ago) with a newer one (`subtle`)
- Fixed examples (check with `cargo build --all`)