### PR TITLE
feat(metrics): Rework OpenTelemetry integration + miscellanea

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,1 @@
-doc-valid-idents = ["OpenAPI", "OpenTelemetry", "RapiDoc", "RusTLS", "EdDSA", ".."]
+doc-valid-idents = ["OpenAPI", "OpenTelemetry", "OTel", "RapiDoc", "RusTLS", "EdDSA", ".."]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install protoc
         uses: arduino/setup-protoc@v3
       - name: Install release tool

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Package cache
         uses: Swatinem/rust-cache@v2
       - name: Install protoc
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Package cache
         uses: Swatinem/rust-cache@v2
       - name: Install protoc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ password-hash = { version = "0.5", features = ["alloc"] }
 pbkdf2 = { version = "0.12", features = ["simple"], optional = true }
 problemdetails = { version = "0.6", features = ["axum"] }
 prometheus = "0.14"
-prost = { version = "0.13", optional = true }
+prost = { version = "0.14", optional = true }
 rdkafka = { version = "0.38", features = ["ssl", "ssl-vendored", "zstd"], optional = true }
 recloser = "1.1"
 regex = "1.11.2"
@@ -91,7 +91,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["alloc", "arbitrary_precision", "preserve_order"] }
 socket2 = { version = "0.6" }
 thiserror = "2.0"
-tonic = { version = "0.13", optional = true }
+tonic = { version = "0.14", optional = true }
 tonic_012 = { version = "0.12.3", package = "tonic" }
 tokio = { version = "1.44", features = ["full"] }
 tower = { version = "0.5", features = ["buffer", "filter", "limit", "retry", "timeout", "util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxum"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Alex Unigovsky <unik@devrandom.ru>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -52,7 +52,8 @@ deboog = "0.2"
 dyn-clone = "1.0"
 forwarded-header-value = "0.1"
 futures = "0.3"
-gettid = "0.1"
+# XXX: gettid 0.1.4 breaks on systems with a really ancient libc.
+gettid = "=0.1.3"
 governor = "0.10"
 humantime-serde = "1.1"
 http = "1.3"
@@ -66,12 +67,12 @@ mime = "0.3"
 okapi = { version = "0.7", features = ["preserve_order"] }
 parking_lot = "0.12"
 pin-project = "1.1"
-opentelemetry = { version = "0.29", features = ["metrics"] }
-opentelemetry-otlp = { version = "0.29", features = ["trace", "metrics", "logs", "grpc-tonic", "zstd-tonic", "tls-roots"] }
-opentelemetry-resource-detectors = "0.8"
-opentelemetry_sdk = { version = "0.29", features = ["rt-tokio", "spec_unstable_metrics_views"] }
-opentelemetry-prometheus = { version = "0.29", features = ["prometheus-encoding"] }
-opentelemetry-semantic-conventions = "0.29"
+opentelemetry = { version = "0.30", features = ["metrics"] }
+opentelemetry-otlp = { version = "0.30", features = ["trace", "metrics", "logs", "grpc-tonic", "zstd-tonic", "tls-roots"] }
+opentelemetry-prometheus-text-exporter = "0.2"
+opentelemetry-resource-detectors = "0.9"
+opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"] }
+opentelemetry-semantic-conventions = "0.30"
 password-hash = { version = "0.5", features = ["alloc"] }
 pbkdf2 = { version = "0.12", features = ["simple"], optional = true }
 problemdetails = { version = "0.6", features = ["axum"] }
@@ -91,15 +92,15 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["alloc", "arbitrary_precision", "preserve_order"] }
 socket2 = { version = "0.6" }
 thiserror = "2.0"
-tonic = { version = "0.14", optional = true }
-tonic_012 = { version = "0.12.3", package = "tonic" }
+tonic = { version = "0.14", features = ["tls-native-roots"], optional = true }
 tokio = { version = "1.44", features = ["full"] }
+tokio-util = "0.7"
 tower = { version = "0.5", features = ["buffer", "filter", "limit", "retry", "timeout", "util"] }
 tower-http = { version = "0.6", features = ["catch-panic", "cors", "request-id", "sensitive-headers", "set-header", "trace", "util"] }
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-log = "0.2"
-tracing-opentelemetry = "0.30"
+tracing-opentelemetry = "0.31"
 tracing-serde = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "local-time", "parking_lot", "time", "tracing-log"] }
 url = { version = "2.5", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ opentelemetry-prometheus-text-exporter = "0.2"
 opentelemetry-resource-detectors = "0.9"
 opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"] }
 opentelemetry-semantic-conventions = "0.30"
+opentelemetry-stdout = { version = "0.30", features = ["trace", "metrics", "logs"] }
 password-hash = { version = "0.5", features = ["alloc"] }
 pbkdf2 = { version = "0.12", features = ["simple"], optional = true }
 problemdetails = { version = "0.6", features = ["axum"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ schemars = { version = "0.8", features = ["bytes", "chrono", "preserve_order", "
 scrypt = { version = "0.11", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["alloc", "arbitrary_precision", "preserve_order"] }
-socket2 = { version = "0.5" }
+socket2 = { version = "0.6" }
 thiserror = "2.0"
 tonic = { version = "0.13", optional = true }
 tonic_012 = { version = "0.12.3", package = "tonic" }

--- a/README.md
+++ b/README.md
@@ -32,3 +32,4 @@ An opinionated backend service framework based on axum.
  * `jwt`: support athentication via HTTP Bearer using [JWT](https://datatracker.ietf.org/doc/html/rfc7519).
  * `kafka`: support writing logs to a Kafka topic.
  * `systemd`: enable systemd integration for service notifications and watchdog support (Linux only).
+ * `full`: kitchen sink mode, enable every feature.

--- a/examples/advanced_server/Cargo.toml
+++ b/examples/advanced_server/Cargo.toml
@@ -10,14 +10,15 @@ description = "UXUM framework - example kitchen sink service with advanced featu
 publish = false
 
 [dependencies]
-prost = "0.13"
+prost = "0.14"
 rand = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
-tonic = "0.13"
-tonic-reflection = "0.13"
+tonic = "0.14"
+tonic-prost = "0.14"
+tonic-reflection = "0.14"
 uxum = { path = "../..", features = ["grpc", "systemd"] }
 tracing = { version = "0.1", features = ["std"] }
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = "0.14"

--- a/examples/advanced_server/build.rs
+++ b/examples/advanced_server/build.rs
@@ -2,7 +2,7 @@ use std::{env, path::PathBuf};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .build_server(true)
         .build_client(false)
         .file_descriptor_set_path(out_dir.join("advanced_server.bin"))

--- a/examples/advanced_server/config.yaml
+++ b/examples/advanced_server/config.yaml
@@ -50,7 +50,7 @@ handlers:
     cors:
       origins: any
       max_age: 60s
-metrics:
+telemetry:
   labels:
     env: example
 tracing:

--- a/examples/advanced_server/config.yaml
+++ b/examples/advanced_server/config.yaml
@@ -5,9 +5,12 @@ logging:
       targets:
         h2: INFO
         hyper: INFO
+        rdkafka: INFO
         tonic: INFO
         tower: INFO
       color: true
+      print:
+        target: true
     - format: compact
       level: DEBUG
       output:
@@ -54,7 +57,9 @@ telemetry:
   labels:
     env: example
 tracing:
-  endpoint: http://localhost:4317
+  exporters:
+    - type: otlp
+      endpoint: http://localhost:4317
   include:
     location: true
     exception_from_error_fields: true

--- a/examples/advanced_server/src/main.rs
+++ b/examples/advanced_server/src/main.rs
@@ -39,7 +39,11 @@ async fn run(mut config: ServiceConfig) -> Result<(), HandleError> {
     //
     // Logging will start working right after this call, and until the returned
     // guard is dropped.
-    let mut handle = config.app.handle().expect("Error initializing handle");
+    let mut handle = config
+        .app
+        .handle()
+        .await
+        .expect("Error initializing handle");
     // Create app builder from app config.
     //
     // Also enable the auth subsystem.

--- a/examples/inner_service/config.yaml
+++ b/examples/inner_service/config.yaml
@@ -22,10 +22,10 @@ logging:
       current_span: true
       static_fields:
         user: $USER
-        something: $PATH, lol $KEK and $USER ($USER) 
+        something: $PATH, lol $KEK and $USER ($USER)
         other: 42
       parse_env_in_static: true
-metrics:
+telemetry:
   labels:
     env: example
 tracing:

--- a/examples/inner_service/config.yaml
+++ b/examples/inner_service/config.yaml
@@ -29,7 +29,9 @@ telemetry:
   labels:
     env: example
 tracing:
-  endpoint: http://localhost:4317
+  exporters:
+    - type: otlp
+      endpoint: http://localhost:4317
   include:
     location: true
     exception_from_error_fields: true

--- a/examples/inner_service/src/main.rs
+++ b/examples/inner_service/src/main.rs
@@ -18,11 +18,11 @@ async fn main() {
         .app
         .with_app_name("inner_service")
         .with_app_version("2.3.4");
-    // Initialize uxum handle, including logging and tracing
+    // Initialize uxum handle, including logging, tracing and metrics.
     //
     // Logging will start working right after this call, and until the returned
     // guard is dropped.
-    let _uxum_handle = app_cfg.handle().expect("Error initializing handle");
+    let _uxum_handle = app_cfg.handle().await.expect("Error initializing handle");
     // Create app builder from app config
     //
     // Also enable the auth subsystem.

--- a/examples/redis-kv/Cargo.toml
+++ b/examples/redis-kv/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 bb8 = "0.9"
-bb8-redis = "0.21"
+bb8-redis = "0.24"
 clap = {version = "4.5", features = ["derive", "env"]}
 humantime-serde = "1.1"
 serde = {version = "1.0", features = ["derive"]}

--- a/examples/redis-kv/config.yaml
+++ b/examples/redis-kv/config.yaml
@@ -8,7 +8,9 @@ logging:
     - format: compact
       level: DEBUG
 tracing:
-  endpoint: http://localhost:4317
+  exporters:
+    - type: otlp
+      endpoint: http://localhost:4317
   include:
     location: true
     exception_from_error_fields: true

--- a/examples/redis-kv/src/main.rs
+++ b/examples/redis-kv/src/main.rs
@@ -166,7 +166,7 @@ async fn run(args: Args, mut config: ServiceConfig<LocalConfig>) -> Result<(), a
     //
     // Logging will start working right after this call, and until the returned
     // guard is dropped.
-    let mut handle = config.app.handle()?;
+    let mut handle = config.app.handle().await?;
     // Create app builder from app config.
     //
     // Also enable the auth subsystem.
@@ -183,8 +183,6 @@ async fn run(args: Args, mut config: ServiceConfig<LocalConfig>) -> Result<(), a
             .with_tag("set", Some("KV setters"), None::<&str>)
     });
     // Initialize application state.
-    // FIXME: transparently initialize metrics and traces in correct order.
-    let _ = app_builder.metrics();
     let manager = RedisConnectionManager::new(config.service.redis.url)?;
     let pool = bb8::Pool::builder()
         .max_size(config.service.redis.max_size)

--- a/src/builder/server.rs
+++ b/src/builder/server.rs
@@ -213,7 +213,9 @@ impl ServerBuilder {
     {
         let (sock, addr) = socket(addr_conf).await?;
         let sref = SockRef::from(&sock);
-        let domain = sref.domain().map_err(|err| ServerBuilderError::GetDomain(err.into()))?;
+        let domain = sref
+            .domain()
+            .map_err(|err| ServerBuilderError::GetDomain(err.into()))?;
         if let Some(tos) = self.ip.tos {
             match domain {
                 socket2::Domain::IPV4 => sref.set_tos_v4(tos),

--- a/src/builder/server.rs
+++ b/src/builder/server.rs
@@ -51,6 +51,9 @@ pub enum ServerBuilderError {
     /// Unable to extract local address.
     #[error("Unable to extract local address: {0}")]
     ListenerLocalAddr(hyper::Error),
+    /// Unable to get socket domain.
+    #[error("Unable to get socket domain: {0}")]
+    GetDomain(IoError),
     /// Unable to set `SO_REUSEADDR`.
     #[error("Unable to set SO_REUSEADDR: {0}")]
     SetReuseAddr(IoError),
@@ -63,8 +66,8 @@ pub enum ServerBuilderError {
     /// Unable to set `SO_KEEPALIVE`.
     #[error("Unable to set SO_KEEPALIVE: {0}")]
     SetKeepAlive(IoError),
-    /// Unable to set `IP_TOS`.
-    #[error("Unable to set IP_TOS: {0}")]
+    /// Unable to set `IP_TOS`/`IPV6_TCLASS`.
+    #[error("Unable to set IP_TOS/IPV6_TCLASS: {0}")]
     SetIpTos(IoError),
     /// Unable to set `TCP_MAXSEG`.
     #[error("Unable to set TCP_MAXSEG: {0}")]
@@ -210,9 +213,14 @@ impl ServerBuilder {
     {
         let (sock, addr) = socket(addr_conf).await?;
         let sref = SockRef::from(&sock);
+        let domain = sref.domain().map_err(|err| ServerBuilderError::GetDomain(err.into()))?;
         if let Some(tos) = self.ip.tos {
-            sref.set_tos(tos)
-                .map_err(|err| ServerBuilderError::SetIpTos(err.into()))?;
+            match domain {
+                socket2::Domain::IPV4 => sref.set_tos_v4(tos),
+                socket2::Domain::IPV6 => sref.set_tclass_v6(tos),
+                _ => Ok(()),
+            }
+            .map_err(|err| ServerBuilderError::SetIpTos(err.into()))?;
         }
         if let Some(sz) = self.tcp.recv_buffer {
             sref.set_recv_buffer_size(sz.get())
@@ -223,7 +231,7 @@ impl ServerBuilder {
                 .map_err(|err| ServerBuilderError::SetSendBuffer(err.into()))?;
         }
         if let Some(mss) = self.tcp.mss {
-            sref.set_mss(mss.get())
+            sref.set_tcp_mss(mss.get())
                 .map_err(|err| ServerBuilderError::SetTcpMss(err.into()))?;
         }
         if let Some(idle) = self.tcp.keepalive.idle {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,7 +1,104 @@
-//! A set of utility functions for working with crypto providers.
+//! A set of utility functions for working with crypto providers and configuration.
+
+use std::path::PathBuf;
+
+use opentelemetry_otlp::tonic_types::transport::{Certificate, ClientTlsConfig, Identity};
+use serde::{Deserialize, Serialize};
+
+use crate::util::fs::read_file;
 
 /// Ensure that the default crypto provider is installed.
 /// It is ok for `install_default()` to fail if the crypto provider is already installed.
 pub fn ensure_default_crypto_provider() {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}
+
+/// TLS configuration for OpenTelemetry exporters.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[non_exhaustive]
+pub struct TonicTlsConfig {
+    /// Require server certificate to be issued against specified domain name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
+    /// List of CA certificates to load for the purpose of server certificate verification.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ca_certs: Vec<PathBuf>,
+    /// Client
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<TlsIdentity>,
+    /// Assume the server supports HTTP/2 even when it doesn't provide protocol negotiation via
+    /// ALPN.
+    #[serde(default)]
+    pub assume_http2: bool,
+    /// Enable platform-native TLS root store.
+    #[serde(default = "crate::util::default_true")]
+    with_native_roots: bool,
+    /// Use key log as specified by the `SSLKEYLOGFILE` environment variable.
+    #[serde(default)]
+    pub use_key_log: bool,
+}
+
+impl Default for TonicTlsConfig {
+    fn default() -> Self {
+        Self {
+            domain: None,
+            ca_certs: Vec::new(),
+            identity: None,
+            assume_http2: false,
+            with_native_roots: true,
+            use_key_log: false,
+        }
+    }
+}
+
+impl TonicTlsConfig {
+    /// Create TLS client configuration for use with [`tonic`].
+    ///
+    /// # Errors
+    ///
+    /// This call will error out if some certificate or key files could not be loaded from
+    /// filesystem.
+    pub async fn to_tonic_config(&self) -> Result<ClientTlsConfig, std::io::Error> {
+        let mut cfg = ClientTlsConfig::new().assume_http2(self.assume_http2);
+        if let Some(domain) = &self.domain {
+            cfg = cfg.domain_name(domain);
+        }
+        for path in &self.ca_certs {
+            let buf = read_file(path).await?;
+            cfg = cfg.ca_certificate(Certificate::from_pem(buf));
+        }
+        if let Some(identity) = &self.identity {
+            cfg = cfg.identity(identity.to_tonic_identity().await?);
+        }
+        if self.with_native_roots {
+            cfg = cfg.with_native_roots();
+        }
+        if self.use_key_log {
+            cfg = cfg.use_key_log();
+        }
+        Ok(cfg)
+    }
+}
+
+/// Client certificate and private key to use.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[non_exhaustive]
+pub struct TlsIdentity {
+    /// Path to client certificate.
+    cert: PathBuf,
+    /// Path to client private key.
+    key: PathBuf,
+}
+
+impl TlsIdentity {
+    /// Create identity object for use in [`tonic`] configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if unable to load certificate or key files.
+    pub async fn to_tonic_identity(&self) -> Result<Identity, std::io::Error> {
+        let cert = read_file(&self.cert).await?;
+        let key = read_file(&self.key).await?;
+        Ok(Identity::from_pem(cert, key))
+    }
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -2,13 +2,12 @@
 
 use std::{
     borrow::Cow,
-    collections::HashMap,
     future::Future,
     ops::Deref,
     pin::Pin,
     sync::Arc,
     task::{ready, Context, Poll},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use axum::{
@@ -20,33 +19,46 @@ use axum::{
 };
 use hyper::{Method, Request};
 use opentelemetry::{
-    global,
-    metrics::{Counter, Gauge, Histogram, MeterProvider, UpDownCounter},
+    metrics::{Counter, Gauge, Histogram, Meter, UpDownCounter},
     KeyValue,
 };
+use opentelemetry_otlp::{ExporterBuildError, WithExportConfig, WithTonicConfig};
+use opentelemetry_prometheus_text_exporter::PrometheusExporter;
 use opentelemetry_sdk::{
-    metrics::{new_view, Aggregation, Instrument, InstrumentKind, MeterProviderBuilder, Stream},
+    metrics::{SdkMeterProvider, Temporality},
     Resource,
 };
 use pin_project::pin_project;
-use prometheus::{Encoder, Registry, TextEncoder};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tokio_util::sync::CancellationToken;
 use tower::{Layer, Service};
-use tracing::{debug_span, trace};
+use tracing::{debug_span, trace, Instrument};
+use url::Url;
 
-use crate::{errors, layers::ext::HandlerName};
+use crate::{
+    crypto::TonicTlsConfig,
+    errors::{self, IoError},
+    layers::ext::HandlerName,
+    telemetry::OtlpProtocol,
+};
 
 /// Error type used in metrics subsystem.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum MetricsError {
-    /// Prometheus exporter error.
-    #[error("Prometheus error: {0}")]
-    Prometheus(#[from] prometheus::Error),
     /// OpenTelemetry metrics error.
-    #[error("OTel metrics error: {0}")]
-    OpenTelemetry(#[from] opentelemetry_sdk::metrics::MetricError),
+    #[error("OTel metrics setup error: {0}")]
+    OpenTelemetry(#[from] ExporterBuildError),
+    /// Error loading files in configuration.
+    #[error("Error loading files in configuration: {0}")]
+    ConfigRead(IoError),
+    /// Error collecting metrics.
+    #[error("Error collecting Prometheus metrics: {0}")]
+    Prometheus(IoError),
+    /// Metrics subsystem is misconfigured.
+    #[error("Metrics subsystem is misconfigured")]
+    RuntimeConfig,
 }
 
 impl IntoResponse for MetricsError {
@@ -62,9 +74,12 @@ impl IntoResponse for MetricsError {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[non_exhaustive]
 pub struct MetricsBuilder {
-    /// Whether HTTP metrics gathering is enabled.
-    #[serde(default = "crate::util::default_true")]
-    enabled: bool,
+    /// List of exporters to supply metrics to.
+    #[serde(
+        default = "MetricsBuilder::default_exporters",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    exporters: Vec<MetricsExporterConfig>,
     /// Histogram metric buckets for total request duration.
     ///
     /// Measured in seconds.
@@ -75,31 +90,42 @@ pub struct MetricsBuilder {
     /// Measured in bytes.
     #[serde(default = "MetricsBuilder::default_size_buckets")]
     size_buckets: Vec<f64>,
-    /// URL path for metrics prometheus exporter endpoint.
-    #[serde(default = "MetricsBuilder::default_metrics_path")]
-    metrics_path: String,
-    /// Static labels to add to gathered metrics.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    labels: HashMap<String, String>,
-    /// Optional prefix for metric names.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    prefix: Option<String>,
+    /// Time interval between recording runtime metrics.
+    #[serde(
+        default = "MetricsBuilder::default_runtime_metrics_interval",
+        with = "humantime_serde"
+    )]
+    pub runtime_metrics_interval: Duration,
 }
 
 impl Default for MetricsBuilder {
     fn default() -> Self {
         Self {
-            enabled: true,
+            exporters: Self::default_exporters(),
             duration_buckets: Self::default_duration_buckets(),
             size_buckets: Self::default_size_buckets(),
-            metrics_path: Self::default_metrics_path(),
-            labels: HashMap::new(),
-            prefix: None,
+            runtime_metrics_interval: Self::default_runtime_metrics_interval(),
+        }
+    }
+}
+
+impl From<MetricsExporterConfig> for MetricsBuilder {
+    fn from(value: MetricsExporterConfig) -> Self {
+        Self {
+            exporters: vec![value],
+            ..Default::default()
         }
     }
 }
 
 impl MetricsBuilder {
+    /// Default value for [`Self::exporters`].
+    #[must_use]
+    #[inline]
+    fn default_exporters() -> Vec<MetricsExporterConfig> {
+        vec![MetricsExporterConfig::default()]
+    }
+
     /// Default value for [`Self::duration_buckets`].
     #[must_use]
     #[inline]
@@ -142,18 +168,11 @@ impl MetricsBuilder {
         .into()
     }
 
-    /// Default value for [`Self::metrics_path`].
+    /// Default value for [`Self::runtime_metrics_interval`].
     #[must_use]
     #[inline]
-    fn default_metrics_path() -> String {
-        "/metrics".into()
-    }
-
-    /// Whether HTTP metrics gathering is enabled.
-    #[must_use]
-    #[inline]
-    pub fn is_enabled(&self) -> bool {
-        self.enabled
+    fn default_runtime_metrics_interval() -> Duration {
+        Duration::from_secs(15)
     }
 
     /// Set histogram metric buckets for total request duration.
@@ -178,107 +197,55 @@ impl MetricsBuilder {
         self
     }
 
-    /// Set URL path for metrics prometheus exporter endpoint.
+    /// Set interval to collect runtime metrics.
     #[must_use]
-    pub fn with_metrics_path<B, S>(mut self, path: impl ToString) -> Self {
-        self.metrics_path = path.to_string();
+    pub fn with_runtime_metrics_interval(mut self, interval: Duration) -> Self {
+        self.runtime_metrics_interval = interval;
         self
     }
 
-    /// Add one static label to be added to gathered metrics.
-    #[must_use]
-    pub fn with_label<T, U>(mut self, key: T, value: U) -> Self
-    where
-        T: ToString,
-        U: ToString,
-    {
-        self.labels.insert(key.to_string(), value.to_string());
-        self
-    }
-
-    /// Add multiple static labels to be added to gathered metrics.
-    #[must_use]
-    pub fn with_labels<'a, T, U, V>(mut self, kvs: V) -> Self
-    where
-        T: ToString + 'a,
-        U: ToString + 'a,
-        V: IntoIterator<Item = (&'a T, &'a U)>,
-    {
-        self.labels.extend(
-            kvs.into_iter()
-                .map(|(key, val)| (key.to_string(), val.to_string())),
-        );
-        self
-    }
-
-    /// Set optional prefix for metric names.
+    /// Build OpenTelemetry metrics provider.
     ///
-    /// Defaults to no prefix used.
-    #[must_use]
-    pub fn with_prefix(mut self, prefix: impl ToString) -> Self {
-        self.prefix = Some(prefix.to_string());
-        self
-    }
-
-    /// Build new Prometheus registry.
-    fn build_prometheus_registry(&self) -> Result<Registry, MetricsError> {
-        Registry::new_custom(
-            self.prefix.clone(),
-            if self.labels.is_empty() {
-                None
-            } else {
-                Some(self.labels.clone())
-            },
-        )
-        .map_err(Into::into)
-    }
-
-    /// Build metrics state object.
+    /// Returns built provider, and a Prometheus exporter, if it was mentioned in configuration.
+    /// You should use this exporter from within a handler to generate metrics in text format.
     ///
     /// # Errors
     ///
-    /// Returns `Err` if metrics registry or provider could not be initialized.
-    pub fn build_state(&self, resource: Resource) -> Result<MetricsState, MetricsError> {
-        let _span = debug_span!("build_metrics").entered();
-        let registry = self.build_prometheus_registry()?;
-        let exporter = opentelemetry_prometheus::exporter()
-            .with_registry(registry.clone())
-            .build()?;
-        let mut all_hist = Instrument::new().name("*");
-        all_hist.kind = Some(InstrumentKind::Histogram);
-        let provider = MeterProviderBuilder::default()
-            .with_resource(resource)
-            .with_reader(exporter)
-            .with_view(new_view(
-                Instrument::new().name("*http.server.request.body.size"),
-                Stream::new().aggregation(Aggregation::ExplicitBucketHistogram {
-                    boundaries: self.size_buckets.clone(),
-                    record_min_max: true,
-                }),
-            )?)
-            .with_view(new_view(
-                Instrument::new().name("*http.server.response.body.size"),
-                Stream::new().aggregation(Aggregation::ExplicitBucketHistogram {
-                    boundaries: self.size_buckets.clone(),
-                    record_min_max: true,
-                }),
-            )?)
-            .with_view(new_view(
-                all_hist,
-                Stream::new().aggregation(Aggregation::ExplicitBucketHistogram {
-                    boundaries: self.duration_buckets.clone(),
-                    record_min_max: true,
-                }),
-            )?)
-            .build();
+    /// Returns `Err` if metrics exporter and/or processor cannot be installed for some reason.
+    pub async fn build_provider(
+        &self,
+        resource: Resource,
+    ) -> Result<(SdkMeterProvider, Option<PrometheusExporter>), MetricsError> {
+        let span = debug_span!("build_tracing_provider");
+        async {
+            let mut prom = None;
+            let mut provider = SdkMeterProvider::builder().with_resource(resource);
+            for exp_cfg in &self.exporters {
+                match exp_cfg {
+                    MetricsExporterConfig::Prometheus(cfg) => {
+                        let exp = cfg.build_exporter();
+                        prom = Some(exp.clone());
+                        provider = provider.with_reader(exp);
+                    }
+                    MetricsExporterConfig::Otlp(cfg) => {
+                        let exp = cfg.build_exporter().await?;
+                        provider = provider.with_periodic_exporter(exp);
+                    }
+                }
+            }
+            Ok((provider.build(), prom))
+        }
+        .instrument(span)
+        .await
+    }
 
-        global::set_meter_provider(provider.clone());
-        let meter = provider.meter("uxum");
-
+    /// Build metrics state object.
+    pub fn build_state(&self, meter: &Meter, prom: Option<PrometheusExporter>) -> MetricsState {
         // HTTP server metrics.
         let request_duration = meter
             .f64_histogram("http.server.request.duration")
             .with_unit("s")
+            .with_boundaries(self.duration_buckets.clone())
             .with_description("The HTTP request latencies in seconds.")
             .build();
         let requests_total = meter
@@ -294,11 +261,13 @@ impl MetricsBuilder {
         let request_body_size = meter
             .u64_histogram("http.server.request.body.size")
             .with_unit("By")
+            .with_boundaries(self.size_buckets.clone())
             .with_description("The HTTP request body sizes in bytes.")
             .build();
         let response_body_size = meter
             .u64_histogram("http.server.response.body.size")
             .with_unit("By")
+            .with_boundaries(self.size_buckets.clone())
             .with_description("The HTTP reponse body sizes in bytes.")
             .build();
         let http_server = HttpServerMetrics {
@@ -313,6 +282,7 @@ impl MetricsBuilder {
         let request_duration = meter
             .f64_histogram("http.client.request.duration")
             .with_unit("s")
+            .with_boundaries(self.duration_buckets.clone())
             .with_description("The HTTP request latencies in seconds.")
             .build();
         let requests_total = meter
@@ -336,11 +306,13 @@ impl MetricsBuilder {
         let request_body_size = meter
             .u64_histogram("http.client.request.body.size")
             .with_unit("By")
+            .with_boundaries(self.size_buckets.clone())
             .with_description("The HTTP request body sizes in bytes.")
             .build();
         let response_body_size = meter
             .u64_histogram("http.client.response.body.size")
             .with_unit("By")
+            .with_boundaries(self.size_buckets.clone())
             .with_description("The HTTP reponse body sizes in bytes.")
             .build();
         let http_client = HttpClientMetricsInner {
@@ -373,13 +345,214 @@ impl MetricsBuilder {
             global_queue_depth,
         };
 
-        Ok(MetricsState {
-            registry,
+        MetricsState {
             http_server,
             http_client,
             runtime,
-            metrics_path: self.metrics_path.clone(),
-        })
+            prom,
+        }
+    }
+
+    /// Build Axum router containing all metrics methods.
+    pub fn build_router(&self, metrics_state: &MetricsState) -> Router {
+        let _span = debug_span!("build_metrics_router").entered();
+        let mut rtr = Router::new();
+        for exp_cfg in &self.exporters {
+            if let MetricsExporterConfig::Prometheus(cfg) = exp_cfg {
+                rtr = rtr.route(&cfg.path, routing::get(get_prom_metrics))
+            }
+        }
+        rtr.with_state(metrics_state.clone())
+    }
+}
+
+/// Configuration for OpenTelemetry metrics exporter.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum MetricsExporterConfig {
+    /// Export metrics via a local handler that returns collected metrics in Prometheus text
+    /// format.
+    #[serde(alias = "prom")]
+    Prometheus(PrometheusMetricsExporterConfig),
+    /// Export metrics via pushing to a remote OTLP endpoint.
+    Otlp(OtlpMetricsExporterConfig),
+}
+
+impl Default for MetricsExporterConfig {
+    fn default() -> Self {
+        Self::Prometheus(Default::default())
+    }
+}
+
+/// Configuration for OpenTelemetry Prometheus metrics exporter.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[non_exhaustive]
+struct PrometheusMetricsExporterConfig {
+    /// URL path for metrics prometheus exporter endpoint.
+    #[serde(default = "PrometheusMetricsExporterConfig::default_path")]
+    path: String,
+    /// Use automatic unit suffixes (e.g., `_seconds`, `_bytes`).
+    #[serde(default = "crate::util::default_true")]
+    with_units: bool,
+    /// Use `_total` suffix on counter metrics.
+    #[serde(default = "crate::util::default_true")]
+    with_counter_suffixes: bool,
+    /// Generate `target_info` metric from resource attributes.
+    #[serde(default = "crate::util::default_true")]
+    with_target_info: bool,
+    /// Generate `otel_scope_info` metric with instrumentation scope labels.
+    #[serde(default = "crate::util::default_true")]
+    with_scope_info: bool,
+}
+
+impl Default for PrometheusMetricsExporterConfig {
+    fn default() -> Self {
+        Self {
+            path: Self::default_path(),
+            with_units: true,
+            with_counter_suffixes: true,
+            with_target_info: true,
+            with_scope_info: true,
+        }
+    }
+}
+
+impl PrometheusMetricsExporterConfig {
+    /// Default value for [`Self::path`].
+    #[must_use]
+    #[inline]
+    fn default_path() -> String {
+        String::from("/metrics")
+    }
+
+    /// Build exporter.
+    #[must_use]
+    fn build_exporter(&self) -> PrometheusExporter {
+        let mut builder = PrometheusExporter::builder();
+        if !self.with_units {
+            builder = builder.without_units();
+        }
+        if !self.with_counter_suffixes {
+            builder = builder.without_counter_suffixes();
+        }
+        if !self.with_target_info {
+            builder = builder.without_target_info();
+        }
+        if !self.with_scope_info {
+            builder = builder.without_scope_info();
+        }
+        builder.build()
+    }
+}
+
+/// Configuration for OpenTelemetry OTLP metrics exporter.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[non_exhaustive]
+struct OtlpMetricsExporterConfig {
+    /// Metrics collector endpoint URL.
+    #[serde(default = "OtlpMetricsExporterConfig::default_endpoint")]
+    endpoint: Url,
+    /// Protocol to use when exporting data.
+    #[serde(default, alias = "format")]
+    protocol: OtlpProtocol,
+    /// Timeout for an outbound exporter request.
+    #[serde(
+        default = "OtlpMetricsExporterConfig::default_timeout",
+        with = "humantime_serde"
+    )]
+    timeout: Duration,
+    /// Default temporality for collected metrics.
+    #[serde(default)]
+    temporality: MetricsTemporality,
+    /// TLS configuration for exporter.
+    #[serde(default)]
+    tls: TonicTlsConfig,
+}
+
+impl Default for OtlpMetricsExporterConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: Self::default_endpoint(),
+            protocol: OtlpProtocol::default(),
+            timeout: Self::default_timeout(),
+            temporality: MetricsTemporality::default(),
+            tls: TonicTlsConfig::default(),
+        }
+    }
+}
+
+impl OtlpMetricsExporterConfig {
+    /// Default value for [`Self::endpoint`].
+    #[must_use]
+    #[inline]
+    #[allow(clippy::unwrap_used)]
+    fn default_endpoint() -> Url {
+        // TODO: check correctness using a unit test.
+        Url::parse("http://localhost:9090/api/v1/otlp/v1/metrics").unwrap()
+    }
+
+    /// Default value for [`Self::timeout`].
+    #[must_use]
+    #[inline]
+    fn default_timeout() -> Duration {
+        opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT
+    }
+
+    /// Try building exporter.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if some files required to properly initialize exporter could not be loaded.
+    async fn build_exporter(&self) -> Result<opentelemetry_otlp::MetricExporter, MetricsError> {
+        opentelemetry_otlp::MetricExporter::builder()
+            .with_tonic()
+            .with_endpoint(self.endpoint.to_string())
+            .with_protocol(self.protocol.into())
+            .with_timeout(self.timeout)
+            .with_tls_config(
+                self.tls
+                    .to_tonic_config()
+                    .await
+                    .map_err(|err| MetricsError::ConfigRead(err.into()))?,
+            )
+            .with_temporality(self.temporality.into())
+            .build()
+            .map_err(Into::into)
+    }
+}
+
+/// Defines the window that an aggregation was calculated over.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Hash, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum MetricsTemporality {
+    /// A measurement interval that continues to expand forward in time from a
+    /// starting point.
+    ///
+    /// New measurements are added to all previous measurements since a start time.
+    #[default]
+    Cumulative,
+
+    /// A measurement interval that resets each cycle.
+    ///
+    /// Measurements from one cycle are recorded independently, measurements from
+    /// other cycles do not affect them.
+    Delta,
+
+    /// Configures Synchronous Counter and Histogram instruments to use
+    /// Delta aggregation temporality, which allows them to shed memory
+    /// following a cardinality explosion, thus use less memory.
+    LowMemory,
+}
+
+impl From<MetricsTemporality> for Temporality {
+    fn from(value: MetricsTemporality) -> Self {
+        match value {
+            MetricsTemporality::Cumulative => Self::Cumulative,
+            MetricsTemporality::Delta => Self::Delta,
+            MetricsTemporality::LowMemory => Self::LowMemory,
+        }
     }
 }
 
@@ -387,18 +560,14 @@ impl MetricsBuilder {
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct MetricsState {
-    /// Prometheus registry.
-    ///
-    /// Holds all configured metrics and their collected values.
-    registry: Registry,
     /// HTTP server metrics.
     http_server: HttpServerMetrics,
     /// HTTP client metrics.
     http_client: HttpClientMetrics,
     /// Tokio runtime metrics.
     runtime: RuntimeMetrics,
-    /// URL path for metrics prometheus exporter.
-    metrics_path: String,
+    /// Prometheus exporter.
+    prom: Option<PrometheusExporter>,
 }
 
 /// Container for HTTP server metrics.
@@ -483,20 +652,27 @@ impl<S> Layer<S> for MetricsState {
 }
 
 impl MetricsState {
-    /// Build Axum router containing all metrics methods.
-    pub fn build_router(&self) -> Router {
-        let _span = debug_span!("build_metrics_router").entered();
-        Router::new()
-            .route(&self.metrics_path, routing::get(get_metrics))
-            .with_state(self.clone())
-    }
-
     /// Get HTTP client metrics state object.
     #[must_use]
     pub fn client_metrics(&self, name: impl AsRef<str>) -> ClientMetricsState {
         ClientMetricsState {
             name: name.as_ref().to_string(),
             metrics: self.http_client.clone(),
+        }
+    }
+
+    /// Get metrics in Prometheus text format, or `None` if no Prometheus exporter was configured.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if encountered an error while collecting metrics.
+    pub fn export_text(&self) -> Result<Option<Vec<u8>>, std::io::Error> {
+        if let Some(exporter) = &self.prom {
+            let mut buf = Vec::with_capacity(256);
+            exporter.export(&mut buf)?;
+            Ok(Some(buf))
+        } else {
+            Ok(None)
         }
     }
 }
@@ -659,26 +835,43 @@ where
     }
 }
 
-/// Method handler to generate metrics.
-async fn get_metrics(metrics: State<MetricsState>) -> Result<impl IntoResponse, MetricsError> {
-    // Record runtime metrics just-in-time.
-    let rt_metrics = tokio::runtime::Handle::current().metrics();
-    metrics
-        .runtime
-        .num_workers
-        .record(rt_metrics.num_workers() as u64, &[]);
-    metrics
-        .runtime
-        .num_alive_tasks
-        .record(rt_metrics.num_alive_tasks() as u64, &[]);
-    metrics
-        .runtime
-        .global_queue_depth
-        .record(rt_metrics.global_queue_depth() as u64, &[]);
+/// Periodic task to record Tokio runtime metrics.
+pub(crate) async fn gather_runtime_metrics(
+    metrics: MetricsState,
+    period: Duration,
+    cancel: CancellationToken,
+) {
+    let mut interval = tokio::time::interval(period);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            _ = interval.tick() => {
+                let rt_metrics = tokio::runtime::Handle::current().metrics();
+                metrics
+                    .runtime
+                    .num_workers
+                    .record(rt_metrics.num_workers() as u64, &[]);
+                metrics
+                    .runtime
+                    .num_alive_tasks
+                    .record(rt_metrics.num_alive_tasks() as u64, &[]);
+                metrics
+                    .runtime
+                    .global_queue_depth
+                    .record(rt_metrics.global_queue_depth() as u64, &[]);
+            }
+        }
+    }
+}
 
+/// Method handler to generate metrics.
+async fn get_prom_metrics(metrics: State<MetricsState>) -> Result<impl IntoResponse, MetricsError> {
     // Serialize metrics.
-    let encoder = TextEncoder::new();
-    let mut buf = Vec::new();
-    encoder.encode(&metrics.registry.gather(), &mut buf)?;
+    let buf = match metrics.export_text() {
+        Ok(Some(buf)) => buf,
+        Ok(None) => return Err(MetricsError::RuntimeConfig),
+        Err(err) => return Err(MetricsError::Prometheus(err.into())),
+    };
     Ok(([(header::CONTENT_TYPE, "text/plain; version=0.0.4")], buf))
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,14 +1,64 @@
 //! Global OpenTelemetry setup code.
 
+use std::collections::HashMap;
+
 use opentelemetry::KeyValue;
+use opentelemetry_otlp::Protocol;
 use opentelemetry_resource_detectors::{OsResourceDetector, ProcessResourceDetector};
 use opentelemetry_sdk::{
     resource::{EnvResourceDetector, SdkProvidedResourceDetector, TelemetryResourceDetector},
     Resource,
 };
 use opentelemetry_semantic_conventions::resource as res;
+use serde::{Deserialize, Serialize};
 
 use crate::config::AppConfig;
+
+/// OpenTelemetry configuration common for logging, metrics and tracing.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct TelemetryConfig {
+    /// Static labels to add to gathered metrics.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    labels: HashMap<String, String>,
+    /// TODO: parse $VARIABLE in label values.
+    #[serde(default)]
+    parse_labels: bool,
+}
+
+impl TelemetryConfig {
+    /// Add one static label to be added to gathered metrics.
+    #[must_use]
+    pub fn with_label<T, U>(&mut self, key: T, value: U) -> &mut Self
+    where
+        T: ToString,
+        U: ToString,
+    {
+        self.labels.insert(key.to_string(), value.to_string());
+        self
+    }
+
+    /// Add multiple static labels to be added to gathered metrics.
+    #[must_use]
+    pub fn with_labels<'a, T, U, V>(&mut self, kvs: V) -> &mut Self
+    where
+        T: ToString + 'a,
+        U: ToString + 'a,
+        V: IntoIterator<Item = (&'a T, &'a U)>,
+    {
+        self.labels.extend(
+            kvs.into_iter()
+                .map(|(key, val)| (key.to_string(), val.to_string())),
+        );
+        self
+    }
+
+    pub fn static_resources(&self) -> impl Iterator<Item = KeyValue> + '_ {
+        self.labels
+            .iter()
+            .map(|(key, val)| KeyValue::new(key.clone(), val.clone()))
+    }
+}
 
 impl AppConfig {
     /// Get OpenTelemetry resource.
@@ -16,20 +66,17 @@ impl AppConfig {
     /// Creates new resource object on first call. On subsequent calls returns previously created
     /// object as a clone.
     #[must_use]
-    pub fn otel_resource(&mut self) -> Resource {
-        if let Some(res) = &self.otel_res {
-            return res.clone();
-        }
+    pub fn otel_resource(&self) -> Resource {
         // TODO: res::SERVICE_NAMESPACE.
         // TODO: res::DEPLOYMENT_ENVIRONMENT.
-        let mut static_resources = Vec::new();
+        let mut static_resources: Vec<_> = self.telemetry.static_resources().collect();
         if let Some(val) = &self.app_name {
             static_resources.push(KeyValue::new(res::SERVICE_NAME, val.clone()));
         }
         if let Some(val) = &self.app_version {
             static_resources.push(KeyValue::new(res::SERVICE_VERSION, val.clone()));
         }
-        let resource = Resource::builder()
+        Resource::builder()
             .with_detectors(&[
                 Box::new(OsResourceDetector),
                 Box::new(ProcessResourceDetector),
@@ -38,8 +85,30 @@ impl AppConfig {
                 Box::new(TelemetryResourceDetector),
             ])
             .with_attributes(static_resources)
-            .build();
-        self.otel_res = Some(resource.clone());
-        resource
+            .build()
+    }
+}
+
+/// OTLP protocol variant to use for data export.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum OtlpProtocol {
+    /// GRPC over HTTP.
+    #[default]
+    Grpc,
+    /// Protobuf over HTTP.
+    HttpBinary,
+    /// JSON over HTTP.
+    HttpJson,
+}
+
+impl From<OtlpProtocol> for Protocol {
+    fn from(value: OtlpProtocol) -> Self {
+        match value {
+            OtlpProtocol::Grpc => Self::Grpc,
+            OtlpProtocol::HttpBinary => Self::HttpBinary,
+            OtlpProtocol::HttpJson => Self::HttpJson,
+        }
     }
 }

--- a/src/util/fs.rs
+++ b/src/util/fs.rs
@@ -1,0 +1,16 @@
+use std::{io, path::Path};
+
+use tokio::{fs, io::AsyncReadExt};
+
+/// Read whole file into new buffer.
+///
+/// # Errors
+///
+/// Returns `Err` if there was an I/O error while opening or reading the file.
+pub(crate) async fn read_file(path: impl AsRef<Path>) -> Result<Vec<u8>, io::Error> {
+    let mut file = fs::OpenOptions::new().read(true).open(path).await?;
+    let meta = file.metadata().await?;
+    let mut buf = Vec::with_capacity(meta.len() as usize);
+    file.read_to_end(&mut buf).await?;
+    Ok(buf)
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,5 +1,7 @@
 //! Misc utility functions and traits.
 
+pub(crate) mod fs;
+
 use std::{
     convert::Infallible,
     future::Future,


### PR DESCRIPTION
* Bump OpenTelemetry to 0.30.
* Can now disable metrics at runtime.
* BREAKING: Can configure multiple metrics exporters in config.
* BREAKING: Can configure multiple tracing exporters in config.
* Swapped (unmaintained) opentelemetry-prometheus for an alternative. Probably will return to first-party exporter after OpenTelemetry stabilization process.
* Moved static labels inside config, to be used for both tracing and metrics OTLP exporters.
* Fix racy metrics initialization.
* Bump tonic/prost, socket2.
* Make exporter TLS parameters configurable.
* Fix garbage trace_id/span_id attributes in logs when tracing is disabled in config.
* Add opentelemetry-stdout support for development and debugging.