### PR TITLE
Disable tracing for internal handlers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxum"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Alex Unigovsky <unik@devrandom.ru>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -69,7 +69,7 @@ parking_lot = "0.12"
 pin-project = "1.1"
 opentelemetry = { version = "0.30", features = ["metrics"] }
 opentelemetry-otlp = { version = "0.30", features = ["trace", "metrics", "logs", "grpc-tonic", "zstd-tonic", "tls-roots"] }
-opentelemetry-prometheus-text-exporter = "0.2"
+opentelemetry-prometheus-text-exporter = "=0.2.0"
 opentelemetry-resource-detectors = "0.9"
 opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"] }
 opentelemetry-semantic-conventions = "0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxum"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Alex Unigovsky <unik@devrandom.ru>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/examples/advanced_server/Cargo.toml
+++ b/examples/advanced_server/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = "2.0"
 tonic = "0.14"
 tonic-prost = "0.14"
 tonic-reflection = "0.14"
-uxum = { path = "../..", features = ["grpc", "systemd"] }
+uxum = { path = "../..", features = ["grpc", "systemd", "jwt", "kafka"] }
 tracing = { version = "0.1", features = ["std"] }
 
 [build-dependencies]

--- a/src/builder/app.rs
+++ b/src/builder/app.rs
@@ -277,17 +277,6 @@ impl AppBuilder {
         let _build_span = debug_span!("build_app").entered();
         let mut rtr = Router::new();
 
-        let metrics_state = self.metrics().cloned();
-        if let (Some(m_state), Some(m_cfg)) = (&metrics_state, &self.config.metrics) {
-            rtr = rtr.merge(m_cfg.build_router(m_state));
-        }
-
-        // Add probes and management mode API.
-        rtr = rtr.merge(self.config.probes.build_router(
-            clone_box(self.auth_provider.as_ref()),
-            clone_box(self.auth_extractor.as_ref()),
-        ));
-
         // A set to ensure uniqueness of handler names.
         let mut handler_names = HashSet::new();
         let mut grouped: BTreeMap<&str, Vec<&dyn HandlerExt>> = BTreeMap::new();
@@ -318,6 +307,40 @@ impl AppBuilder {
             rtr = rtr.merge(self.grpc_services.clone().routes().into_axum_router());
         }
 
+        // TODO: allow customizing fallback handler.
+        rtr = rtr.fallback(fallback_handler);
+
+        // Don't add tracing to probe and metric handlers.
+        let tracing_config = self.config.tracing.as_ref();
+        let include_headers = tracing_config.is_some_and(|t| t.include_headers());
+        let request_level =
+            tracing_config.map_or(tracing::Level::DEBUG, |t| t.request_level().into());
+        let response_level =
+            tracing_config.map_or(tracing::Level::INFO, |t| t.response_level().into());
+        rtr = rtr.layer(
+            // TODO: factor out tracing for GRPC.
+            TraceLayer::new_for_http()
+                .make_span_with(CustomMakeSpan::new().include_headers(include_headers))
+                .on_request(DefaultOnRequest::new().level(request_level))
+                .on_response(
+                    DefaultOnResponse::new()
+                        .level(response_level)
+                        .include_headers(include_headers)
+                        .latency_unit(LatencyUnit::Micros),
+                ),
+        );
+
+        let metrics_state = self.metrics().cloned();
+        if let (Some(m_state), Some(m_cfg)) = (&metrics_state, &self.config.metrics) {
+            rtr = rtr.merge(m_cfg.build_router(m_state));
+        }
+
+        // Add probes and management mode API.
+        rtr = rtr.merge(self.config.probes.build_router(
+            clone_box(self.auth_provider.as_ref()),
+            clone_box(self.auth_extractor.as_ref()),
+        ));
+
         // Add RapiDoc and/or OpenAPI specification generator if enabled.
         if let Some(ref mut api_doc) = self.config.api_doc {
             let disabled = self
@@ -334,9 +357,6 @@ impl AppBuilder {
             let auth = self.auth_extractor.security_schemes();
             rtr = rtr.merge(api_doc.build_router(auth)?);
         }
-
-        // TODO: allow customizing fallback handler.
-        rtr = rtr.fallback(fallback_handler);
 
         // Wrap router in global layers.
         let final_rtr = self.wrap_global_layers(rtr, metrics_state);
@@ -400,30 +420,12 @@ impl AppBuilder {
     /// Wrap router in global [`tower`] layers.
     fn wrap_global_layers(&self, rtr: Router, metrics: Option<MetricsState>) -> Router {
         // [`tower`] layers that are executed for any request.
-        let tracing_config = self.config.tracing.as_ref();
-        let include_headers = tracing_config.is_some_and(|t| t.include_headers());
-        let request_level =
-            tracing_config.map_or(tracing::Level::DEBUG, |t| t.request_level().into());
-        let response_level =
-            tracing_config.map_or(tracing::Level::INFO, |t| t.response_level().into());
         let mut sensitive_headers = vec![header::AUTHORIZATION];
         sensitive_headers.append(&mut self.auth_extractor.sensitive_headers());
         let global_layers = ServiceBuilder::new()
             .set_x_request_id(MakeRequestUuid)
             .layer(RecordRequestIdLayer::new())
             .sensitive_headers(sensitive_headers)
-            .layer(
-                // TODO: factor out tracing for GRPC.
-                TraceLayer::new_for_http()
-                    .make_span_with(CustomMakeSpan::new().include_headers(include_headers))
-                    .on_request(DefaultOnRequest::new().level(request_level))
-                    .on_response(
-                        DefaultOnResponse::new()
-                            .level(response_level)
-                            .include_headers(include_headers)
-                            .latency_unit(LatencyUnit::Micros),
-                    ),
-            )
             .option_layer(metrics)
             .option_layer(if self.config.tracing.is_some() {
                 Some(MapRequestLayer::new(crate::logging::span::register_request))

--- a/uxum-pools/src/sync/impls/dummy.rs
+++ b/uxum-pools/src/sync/impls/dummy.rs
@@ -3,9 +3,11 @@ use std::{convert::Infallible, time::Duration};
 use crate::sync::*;
 
 /// Dummy pool for testing purposes.
+#[allow(dead_code)]
 pub(crate) struct DummyPool;
 
 /// Dummy resource for testing purposes.
+#[allow(dead_code)]
 pub(crate) struct DummyResource;
 
 impl InstrumentablePool<'_> for DummyPool {


### PR DESCRIPTION
### Problem
Users complained that the tracing system is full of useless traces from automatic liveness/readiness probes and metrics scrapes. This noise makes it hard to find traces for real user requests and wastes resources.

### Solution
Disabled distributed tracing for all internal utility handlers:
1. Metrics endpoint (/metrics)
2. Health probes (/probe/live, /probe/ready)
3. Api docs