### PR TITLE
Fix macOS build: derive socket domain from address; pin socket2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxum"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Alex Unigovsky <unik@devrandom.ru>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -92,7 +92,10 @@ schemars = { version = "0.8", features = ["bytes", "chrono", "preserve_order", "
 scrypt = { version = "0.11", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["alloc", "arbitrary_precision", "preserve_order"] }
-socket2 = { version = "0.6" }
+# NOTE: pinned to an exact patch version — socket2 changes frequently and has
+# broken backwards compatibility across patch releases. The `all` feature is
+# required for the socket options used in `builder::server` (TOS, MSS, buffers).
+socket2 = { version = "=0.6.4", features = ["all"] }
 thiserror = "2.0"
 tonic = { version = "0.14", features = ["tls-native-roots"], optional = true }
 tokio = { version = "1.44", features = ["full"] }

--- a/src/builder/server.rs
+++ b/src/builder/server.rs
@@ -213,9 +213,12 @@ impl ServerBuilder {
     {
         let (sock, addr) = socket(addr_conf).await?;
         let sref = SockRef::from(&sock);
-        let domain = sref
-            .domain()
-            .map_err(|err| ServerBuilderError::GetDomain(err.into()))?;
+        // NOTE: socket2's `SockRef::domain()` is only available on Linux/Android/FreeBSD/Fuchsia,
+        // so derive the domain from the resolved address instead (portable, no syscall).
+        let domain = match addr {
+            SocketAddr::V4(_) => socket2::Domain::IPV4,
+            SocketAddr::V6(_) => socket2::Domain::IPV6,
+        };
         if let Some(tos) = self.ip.tos {
             match domain {
                 socket2::Domain::IPV4 => sref.set_tos_v4(tos),


### PR DESCRIPTION
`SockRef::domain()` from socket2 is only compiled on Linux/Android/FreeBSD/Fuchsia, so the library failed to compile on macOS (and any other platform lacking SO_DOMAIN). Derive the socket domain from the already-resolved `SocketAddr` instead — portable and avoids a syscall.

Also declare the `all` feature on socket2 explicitly (the TOS/MSS/buffer socket options require it; it was previously satisfied only transitively via hyper-util/reqwest) and pin socket2 to an exact patch version, since it changes frequently and has broken backwards compatibility across patch releases.

Bump version to 0.9.5.