### PR TITLE
Retries (config, backoff policy, middleware) for http client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxum"
-version = "0.10.0-rc.1"
+version = "0.10.0-rc.2"
 authors = ["Alex Unigovsky <unik@devrandom.ru>"]
 license = "MIT OR Apache-2.0"
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,10 +114,13 @@ tracing-serde = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "local-time", "parking_lot", "time", "tracing-log"] }
 url = { version = "2.5", features = ["serde"] }
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
+reqwest-retry = "0.9.1"
+retry-policies = "0.5.2"
 
 [dev-dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive", "env"] }
+rstest = "0.26"
 
 [features]
 default = ["hash_argon2"]

--- a/src/http_client/config.rs
+++ b/src/http_client/config.rs
@@ -20,6 +20,7 @@ use tokio::{fs::OpenOptions, io::AsyncReadExt};
 #[cfg(feature = "spiffe")]
 use crate::spiffe::SpiffeConfig;
 use crate::{
+    RetryPolicyKind,
     http_client::{
         cb::HttpClientCircuitBreakerConfig, errors::HttpClientError, middleware::wrap_client,
     },
@@ -141,6 +142,13 @@ pub struct HttpClientConfig {
         alias = "circuit_breaker"
     )]
     pub cb: Option<HttpClientCircuitBreakerConfig>,
+    /// Retry configuration.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "retry_config"
+    )]
+    pub retry: Option<RetryPolicyKind>,
     /// List of overrides for domain name resolution.
     ///
     /// Use domain name as key, and a socket address as value.
@@ -172,6 +180,7 @@ impl Default for HttpClientConfig {
             tcp: HttpClientTcpConfig::default(),
             http2: HttpClientHttp2Config::default(),
             cb: None,
+            retry: None,
             domain_overrides: HashMap::new(),
             app_name: None,
             app_version: None,
@@ -322,6 +331,7 @@ impl HttpClientConfig {
             builder.build()?,
             metrics,
             self.cb.as_ref().map(|cb| cb.make_circuit_breaker()),
+            self.retry.as_ref(),
         ))
     }
 

--- a/src/http_client/middleware.rs
+++ b/src/http_client/middleware.rs
@@ -56,7 +56,7 @@ pub(crate) fn wrap_client(
     client: Client,
     metrics: Option<ClientMetricsState>,
     cb: Option<AsyncRecloser>,
-    retry_policy: Option<&RetryPolicyKind>, // fixme
+    retry_policy: Option<&RetryPolicyKind>,
 ) -> ClientWithMiddleware {
     let mut builder = ClientBuilder::new(client)
         .with(HeaderPropagationMiddleware)

--- a/src/http_client/middleware.rs
+++ b/src/http_client/middleware.rs
@@ -70,11 +70,11 @@ pub(crate) fn wrap_client(
     }
     if let Some(policy) = retry_policy {
         match policy {
-            RetryPolicyKind::Base(base) => {
-                builder = builder.with(BaseRetryMiddleware::from(base.clone()));
+            RetryPolicyKind::FixedInterval(v) => {
+                builder = builder.with(BaseRetryMiddleware::from(v.clone()));
             }
-            RetryPolicyKind::Exponential(exp) => {
-                builder = builder.with(ExponentialRetryMiddleware::from(exp.clone()));
+            RetryPolicyKind::ExponentialBackoff(v) => {
+                builder = builder.with(ExponentialRetryMiddleware::from(v.clone()));
             }
         }
     }

--- a/src/http_client/middleware.rs
+++ b/src/http_client/middleware.rs
@@ -6,7 +6,10 @@ use reqwest::{Client, Request, Response};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, Middleware, Next, Result};
 
 use crate::{
-    http_client::{CircuitBreakerMiddleware, MetricsMiddleware, TracingMiddleware},
+    http_client::{
+        BaseRetryMiddleware, CircuitBreakerMiddleware, ExponentialRetryMiddleware,
+        MetricsMiddleware, RetryPolicyKind, TracingMiddleware,
+    },
     layers::{
         request_id::{CURRENT_REQUEST_ID, X_REQUEST_ID},
         timeout::{CURRENT_DEADLINE, X_TIMEOUT},
@@ -53,15 +56,27 @@ pub(crate) fn wrap_client(
     client: Client,
     metrics: Option<ClientMetricsState>,
     cb: Option<AsyncRecloser>,
+    retry_policy: Option<&RetryPolicyKind>, // fixme
 ) -> ClientWithMiddleware {
     let mut builder = ClientBuilder::new(client)
         .with(HeaderPropagationMiddleware)
         .with(TracingMiddleware::new());
+
     if let Some(metrics) = metrics {
         builder = builder.with(MetricsMiddleware::from(metrics));
     }
     if let Some(cb) = cb {
         builder = builder.with(CircuitBreakerMiddleware::from(cb));
+    }
+    if let Some(policy) = retry_policy {
+        match policy {
+            RetryPolicyKind::Base(base) => {
+                builder = builder.with(BaseRetryMiddleware::from(base.clone()));
+            }
+            RetryPolicyKind::Exponential(exp) => {
+                builder = builder.with(ExponentialRetryMiddleware::from(exp.clone()));
+            }
+        }
     }
     builder.build()
 }

--- a/src/http_client/mod.rs
+++ b/src/http_client/mod.rs
@@ -7,6 +7,7 @@ mod config;
 mod errors;
 mod metrics;
 mod middleware;
+mod retry;
 mod tracing;
 
 pub use self::{
@@ -14,5 +15,12 @@ pub use self::{
     config::HttpClientConfig,
     errors::HttpClientError,
     metrics::MetricsMiddleware,
+    retry::{
+        BaseBackoffPolicy, BaseRetryMiddleware, ExponentialBackoffPolicy,
+        ExponentialRetryMiddleware, RetryPolicyKind,
+    },
     tracing::{DisableOtelPropagation, TracingMiddleware},
 };
+pub use reqwest_middleware::ClientWithMiddleware;
+pub use reqwest_middleware::Error as ReqwestMiddlewareError;
+pub use reqwest_middleware::reqwest::Error as ReqwestError;

--- a/src/http_client/mod.rs
+++ b/src/http_client/mod.rs
@@ -16,8 +16,8 @@ pub use self::{
     errors::HttpClientError,
     metrics::MetricsMiddleware,
     retry::{
-        BaseBackoffPolicy, BaseRetryMiddleware, ExponentialBackoffPolicy,
-        ExponentialRetryMiddleware, RetryPolicyKind,
+        BaseRetryMiddleware, ExponentialBackoffPolicy, ExponentialRetryMiddleware,
+        FixedIntervalPolicy, RetryPolicyKind,
     },
     tracing::{DisableOtelPropagation, TracingMiddleware},
 };

--- a/src/http_client/retry.rs
+++ b/src/http_client/retry.rs
@@ -1,4 +1,5 @@
 //! Retry config, strategy and middleware for using on `HttpClient` side
+use std::num::NonZeroU32;
 use reqwest_retry::{DefaultRetryableStrategy, RetryTransientMiddleware};
 use retry_policies::RetryDecision;
 use retry_policies::policies::ExponentialBackoff;
@@ -22,8 +23,8 @@ pub enum RetryPolicyKind {
 pub struct BaseBackoffPolicy {
     /// Number of attempts to retry failed request
     #[serde(alias = "attempts")]
-    max_attempts: u32,
-    /// Backoff duration in seconds
+    max_attempts: NonZeroU32,
+    /// Backoff duration
     #[serde(alias = "duration", with = "humantime_serde")]
     backoff_duration: Duration,
 }
@@ -34,18 +35,18 @@ pub struct BaseBackoffPolicy {
 pub struct ExponentialBackoffPolicy {
     /// Number of attempts to retry failed request
     #[serde(alias = "attempts")]
-    max_attempts: u32,
-    /// Min backoff duration in seconds
+    max_attempts: NonZeroU32,
+    /// Min backoff duration
     #[serde(alias = "min_duration", with = "humantime_serde")]
     min_backoff_duration: Duration,
-    /// Max backoff duration in seconds
+    /// Max backoff duration
     #[serde(alias = "max_duration", with = "humantime_serde")]
     max_backoff_duration: Duration,
 }
 
 impl retry_policies::RetryPolicy for BaseBackoffPolicy {
     fn should_retry(&self, _req_start_time: SystemTime, n_past_retries: u32) -> RetryDecision {
-        if n_past_retries < self.max_attempts {
+        if n_past_retries < self.max_attempts.into() {
             return RetryDecision::Retry {
                 execute_after: SystemTime::now() + self.backoff_duration,
             };
@@ -74,7 +75,7 @@ impl From<ExponentialBackoffPolicy> for ExponentialRetryMiddleware {
     fn from(policy: ExponentialBackoffPolicy) -> Self {
         let policy = ExponentialBackoff::builder()
             .retry_bounds(policy.min_backoff_duration, policy.max_backoff_duration)
-            .build_with_max_retries(policy.max_attempts);
+            .build_with_max_retries(policy.max_attempts.into());
         RetryTransientMiddleware::new_with_policy(policy)
     }
 }
@@ -94,7 +95,7 @@ mod tests {
             }
         }"#,
         RetryPolicyKind::Base(BaseBackoffPolicy {
-            max_attempts: 5,
+            max_attempts: NonZeroU32::new(5).unwrap(),
             backoff_duration: Duration::from_secs(3)})
     )]
     #[case(
@@ -105,7 +106,7 @@ mod tests {
             }
         }"#,
         RetryPolicyKind::Base(BaseBackoffPolicy {
-            max_attempts: 5,
+            max_attempts: NonZeroU32::new(5).unwrap(),
             backoff_duration: Duration::from_secs(3)})
     )]
     #[case(
@@ -117,7 +118,7 @@ mod tests {
             }
         }"#,
         RetryPolicyKind::Exponential(ExponentialBackoffPolicy {
-            max_attempts: 5,
+            max_attempts: NonZeroU32::new(5).unwrap(),
             min_backoff_duration: Duration::from_secs(1),
             max_backoff_duration: Duration::from_secs(3)})
     )]
@@ -130,7 +131,7 @@ mod tests {
             }
         }"#,
         RetryPolicyKind::Exponential(ExponentialBackoffPolicy {
-            max_attempts: 5,
+            max_attempts: NonZeroU32::new(5).unwrap(),
             min_backoff_duration: Duration::from_secs(1),
             max_backoff_duration: Duration::from_secs(3)})
     )]
@@ -151,7 +152,16 @@ mod tests {
                 "backoff_duration": "2s"
             }
         }"#,
-        "invalid value: integer `-1`, expected u32"
+        "invalid value: integer `-1`, expected a nonzero u32"
+    )]
+    #[case(
+        r#"{
+            "backoff_policy": {
+                "max_attempts": 0,
+                "backoff_duration": "2s"
+            }
+        }"#,
+        "invalid value: integer `0`, expected a nonzero u32"
     )]
     #[case(
         r#"{
@@ -170,7 +180,17 @@ mod tests {
                 "max_backoff_duration": "3s"
             }
         }"#,
-        "invalid value: integer `-1`, expected u32"
+        "invalid value: integer `-1`, expected a nonzero u32"
+    )]
+    #[case(
+        r#"{
+            "exponential_backoff_policy": {
+                "max_attempts": 0,
+                "min_backoff_duration": "2s",
+                "max_backoff_duration": "3s"
+            }
+        }"#,
+        "invalid value: integer `0`, expected a nonzero u32"
     )]
     #[case(
         r#"{

--- a/src/http_client/retry.rs
+++ b/src/http_client/retry.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, SystemTime};
 
 /// HTTP client retry policy kind (base or exponential)
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum RetryPolicyKind {
     /// Base backoff policy for retry
@@ -20,6 +21,7 @@ pub enum RetryPolicyKind {
 
 /// HTTP client retry policy with fixed interval between attempts
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub struct FixedIntervalPolicy {
     /// Number of attempts to retry failed request
@@ -32,6 +34,7 @@ pub struct FixedIntervalPolicy {
 
 /// HTTP client retry policy with exponential backoff
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub struct ExponentialBackoffPolicy {
     /// Number of attempts to retry failed request

--- a/src/http_client/retry.rs
+++ b/src/http_client/retry.rs
@@ -1,0 +1,211 @@
+//! Retry config, strategy and middleware for using on `HttpClient` side
+use reqwest_retry::{DefaultRetryableStrategy, RetryTransientMiddleware};
+use retry_policies::RetryDecision;
+use retry_policies::policies::ExponentialBackoff;
+use serde::{Deserialize, Serialize};
+use std::time::{Duration, SystemTime};
+
+/// HTTP client retry policy kind (base or exponential)
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub enum RetryPolicyKind {
+    /// Base backoff policy for retry
+    #[serde(alias = "backoff", alias = "backoff_policy")]
+    Base(BaseBackoffPolicy),
+    /// Exponential backoff policy for retry
+    #[serde(alias = "exponential_backoff", alias = "exponential_backoff_policy")]
+    Exponential(ExponentialBackoffPolicy),
+}
+
+/// HTTP client Base backoff policy for retry
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename = "snake_case")]
+pub struct BaseBackoffPolicy {
+    /// Number of attempts to retry failed request
+    #[serde(alias = "attempts")]
+    max_attempts: u32,
+    /// Backoff duration in seconds
+    #[serde(alias = "duration", with = "humantime_serde")]
+    backoff_duration: Duration,
+}
+
+/// HTTP client Exponential backoff policy for retry
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename = "snake_case")]
+pub struct ExponentialBackoffPolicy {
+    /// Number of attempts to retry failed request
+    #[serde(alias = "attempts")]
+    max_attempts: u32,
+    /// Min backoff duration in seconds
+    #[serde(alias = "min_duration", with = "humantime_serde")]
+    min_backoff_duration: Duration,
+    /// Max backoff duration in seconds
+    #[serde(alias = "max_duration", with = "humantime_serde")]
+    max_backoff_duration: Duration,
+}
+
+impl retry_policies::RetryPolicy for BaseBackoffPolicy {
+    fn should_retry(&self, _req_start_time: SystemTime, n_past_retries: u32) -> RetryDecision {
+        if n_past_retries < self.max_attempts {
+            return RetryDecision::Retry {
+                execute_after: SystemTime::now() + self.backoff_duration,
+            };
+        }
+        RetryDecision::DoNotRetry
+    }
+}
+
+/// Retry middleware based on Base backoff policy
+/// and default Retryable strategy
+pub type BaseRetryMiddleware =
+    RetryTransientMiddleware<BaseBackoffPolicy, DefaultRetryableStrategy>;
+
+impl From<BaseBackoffPolicy> for BaseRetryMiddleware {
+    fn from(policy: BaseBackoffPolicy) -> Self {
+        RetryTransientMiddleware::new_with_policy(policy)
+    }
+}
+
+/// Retry middleware based on Exponential backoff policy
+/// and default Retryable strategy
+pub type ExponentialRetryMiddleware =
+    RetryTransientMiddleware<ExponentialBackoff, DefaultRetryableStrategy>;
+
+impl From<ExponentialBackoffPolicy> for ExponentialRetryMiddleware {
+    fn from(policy: ExponentialBackoffPolicy) -> Self {
+        let policy = ExponentialBackoff::builder()
+            .retry_bounds(policy.min_backoff_duration, policy.max_backoff_duration)
+            .build_with_max_retries(policy.max_attempts);
+        RetryTransientMiddleware::new_with_policy(policy)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::*;
+    use std::time::Duration;
+
+    #[rstest]
+    #[case(
+        r#"{
+            "backoff": {
+                "attempts": 5,
+                "duration": "3s"
+            }
+        }"#,
+        RetryPolicyKind::Base(BaseBackoffPolicy {
+            max_attempts: 5,
+            backoff_duration: Duration::from_secs(3)})
+    )]
+    #[case(
+        r#"{
+            "backoff_policy": {
+                "max_attempts": 5,
+                "backoff_duration": "3s"
+            }
+        }"#,
+        RetryPolicyKind::Base(BaseBackoffPolicy {
+            max_attempts: 5,
+            backoff_duration: Duration::from_secs(3)})
+    )]
+    #[case(
+        r#"{
+            "exponential_backoff": {
+                "attempts": 5,
+                "min_duration": "1s",
+                "max_duration": "3s"
+            }
+        }"#,
+        RetryPolicyKind::Exponential(ExponentialBackoffPolicy {
+            max_attempts: 5,
+            min_backoff_duration: Duration::from_secs(1),
+            max_backoff_duration: Duration::from_secs(3)})
+    )]
+    #[case(
+        r#"{
+            "exponential_backoff_policy": {
+                "max_attempts": 5,
+                "min_backoff_duration": "1s",
+                "max_backoff_duration": "3s"
+            }
+        }"#,
+        RetryPolicyKind::Exponential(ExponentialBackoffPolicy {
+            max_attempts: 5,
+            min_backoff_duration: Duration::from_secs(1),
+            max_backoff_duration: Duration::from_secs(3)})
+    )]
+    fn test_retry_policy_deserialization_ok(
+        #[case] cfg_json: &str,
+        #[case] expected_policy: RetryPolicyKind,
+    ) {
+        let policy = serde_json::from_str::<RetryPolicyKind>(cfg_json);
+        assert!(policy.is_ok(), "Config was not deserialized properly");
+        assert_eq!(policy.unwrap(), expected_policy);
+    }
+
+    #[rstest]
+    #[case(
+        r#"{
+            "backoff_policy": {
+                "max_attempts": -1,
+                "backoff_duration": "2s"
+            }
+        }"#,
+        "invalid value: integer `-1`, expected u32"
+    )]
+    #[case(
+        r#"{
+            "backoff_policy": {
+                "max_attempts": 1,
+                "backoff_duration": "2"
+            }
+        }"#,
+        "invalid value: string \"2\", expected a duration"
+    )]
+    #[case(
+        r#"{
+            "exponential_backoff_policy": {
+                "max_attempts": -1,
+                "min_backoff_duration": "2s",
+                "max_backoff_duration": "3s"
+            }
+        }"#,
+        "invalid value: integer `-1`, expected u32"
+    )]
+    #[case(
+        r#"{
+            "exponential_backoff_policy": {
+                "max_attempts": 1,
+                "min_backoff_duration": "2",
+                "max_backoff_duration": "3s"
+            }
+        }"#,
+        "invalid value: string \"2\", expected a duration"
+    )]
+    #[case(
+        r#"{
+            "exponential_backoff_policy": {
+                "max_attempts": 1,
+                "min_backoff_duration": "2s",
+                "max_backoff_duration": "3"
+            }
+        }"#,
+        "invalid value: string \"3\", expected a duration"
+    )]
+    fn test_retry_policy_deserialization_error(
+        #[case] cfg_json: &str,
+        #[case] expected_err_str: &str,
+    ) {
+        let policy = serde_json::from_str::<RetryPolicyKind>(cfg_json);
+        assert!(policy.is_err());
+        let err_str = policy.unwrap_err().to_string();
+        assert!(
+            err_str.starts_with(expected_err_str),
+            "{}",
+            format!(
+                "error string '{}' should start with substring: {}",
+                err_str, expected_err_str,
+            )
+        )
+    }
+}

--- a/src/http_client/retry.rs
+++ b/src/http_client/retry.rs
@@ -1,36 +1,36 @@
 //! Retry config, strategy and middleware for using on `HttpClient` side
-use std::num::NonZeroU32;
 use reqwest_retry::{DefaultRetryableStrategy, RetryTransientMiddleware};
 use retry_policies::RetryDecision;
 use retry_policies::policies::ExponentialBackoff;
 use serde::{Deserialize, Serialize};
+use std::num::NonZeroU32;
 use std::time::{Duration, SystemTime};
 
 /// HTTP client retry policy kind (base or exponential)
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum RetryPolicyKind {
     /// Base backoff policy for retry
-    #[serde(alias = "backoff", alias = "backoff_policy")]
-    Base(BaseBackoffPolicy),
+    #[serde(alias = "fixed")]
+    FixedInterval(FixedIntervalPolicy),
     /// Exponential backoff policy for retry
-    #[serde(alias = "exponential_backoff", alias = "exponential_backoff_policy")]
-    Exponential(ExponentialBackoffPolicy),
+    #[serde(alias = "exponential")]
+    ExponentialBackoff(ExponentialBackoffPolicy),
 }
 
-/// HTTP client Base backoff policy for retry
+/// HTTP client retry policy with fixed interval between attempts
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub struct BaseBackoffPolicy {
+pub struct FixedIntervalPolicy {
     /// Number of attempts to retry failed request
     #[serde(alias = "attempts")]
     max_attempts: NonZeroU32,
-    /// Backoff duration
-    #[serde(alias = "duration", with = "humantime_serde")]
-    backoff_duration: Duration,
+    /// Duration between retry attempts
+    #[serde(with = "humantime_serde")]
+    duration: Duration,
 }
 
-/// HTTP client Exponential backoff policy for retry
+/// HTTP client retry policy with exponential backoff
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct ExponentialBackoffPolicy {
@@ -45,11 +45,11 @@ pub struct ExponentialBackoffPolicy {
     max_backoff_duration: Duration,
 }
 
-impl retry_policies::RetryPolicy for BaseBackoffPolicy {
+impl retry_policies::RetryPolicy for FixedIntervalPolicy {
     fn should_retry(&self, _req_start_time: SystemTime, n_past_retries: u32) -> RetryDecision {
         if n_past_retries < self.max_attempts.into() {
             return RetryDecision::Retry {
-                execute_after: SystemTime::now() + self.backoff_duration,
+                execute_after: SystemTime::now() + self.duration,
             };
         }
         RetryDecision::DoNotRetry
@@ -59,10 +59,10 @@ impl retry_policies::RetryPolicy for BaseBackoffPolicy {
 /// Retry middleware based on Base backoff policy
 /// and default Retryable strategy
 pub type BaseRetryMiddleware =
-    RetryTransientMiddleware<BaseBackoffPolicy, DefaultRetryableStrategy>;
+    RetryTransientMiddleware<FixedIntervalPolicy, DefaultRetryableStrategy>;
 
-impl From<BaseBackoffPolicy> for BaseRetryMiddleware {
-    fn from(policy: BaseBackoffPolicy) -> Self {
+impl From<FixedIntervalPolicy> for BaseRetryMiddleware {
+    fn from(policy: FixedIntervalPolicy) -> Self {
         RetryTransientMiddleware::new_with_policy(policy)
     }
 }
@@ -85,97 +85,122 @@ impl From<ExponentialBackoffPolicy> for ExponentialRetryMiddleware {
 mod tests {
     use super::*;
     use rstest::*;
-    use std::time::Duration;
+
+    #[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+    struct TestCfg {
+        retry: Option<RetryPolicyKind>,
+    }
+
+    macro_rules! get_config_with_policy {
+        (kind = "fixed"; $n:expr, $dur:expr) => {{
+            TestCfg {
+                retry: Some(RetryPolicyKind::FixedInterval(FixedIntervalPolicy {
+                    max_attempts: NonZeroU32::new($n).expect("invalid u32"),
+                    duration: std::time::Duration::from_secs($dur),
+                })),
+            }
+        }};
+        (kind = "exponent"; $n:expr, $min_dur:expr, $max_dur:expr) => {{
+            TestCfg {
+                retry: Some(RetryPolicyKind::ExponentialBackoff(
+                    ExponentialBackoffPolicy {
+                        max_attempts: NonZeroU32::new($n).expect("invalid u32"),
+                        min_backoff_duration: std::time::Duration::from_secs($min_dur),
+                        max_backoff_duration: std::time::Duration::from_secs($max_dur),
+                    },
+                )),
+            }
+        }};
+    }
 
     #[rstest]
+    #[case("{}", TestCfg { retry: None })]
     #[case(
         r#"{
-            "backoff": {
+            "retry": {
+                "kind": "fixed",
                 "attempts": 5,
                 "duration": "3s"
             }
         }"#,
-        RetryPolicyKind::Base(BaseBackoffPolicy {
-            max_attempts: NonZeroU32::new(5).unwrap(),
-            backoff_duration: Duration::from_secs(3)})
+        get_config_with_policy!(kind = "fixed"; 5, 3)
     )]
     #[case(
         r#"{
-            "backoff_policy": {
+            "retry": {
+                "kind": "fixed_interval",
                 "max_attempts": 5,
-                "backoff_duration": "3s"
+                "duration": "3s"
             }
         }"#,
-        RetryPolicyKind::Base(BaseBackoffPolicy {
-            max_attempts: NonZeroU32::new(5).unwrap(),
-            backoff_duration: Duration::from_secs(3)})
+        get_config_with_policy!(kind = "fixed"; 5, 3)
     )]
     #[case(
         r#"{
-            "exponential_backoff": {
+            "retry": {
+                "kind": "exponential",
                 "attempts": 5,
                 "min_duration": "1s",
                 "max_duration": "3s"
             }
         }"#,
-        RetryPolicyKind::Exponential(ExponentialBackoffPolicy {
-            max_attempts: NonZeroU32::new(5).unwrap(),
-            min_backoff_duration: Duration::from_secs(1),
-            max_backoff_duration: Duration::from_secs(3)})
+        get_config_with_policy!(kind = "exponent"; 5, 1, 3),
     )]
     #[case(
         r#"{
-            "exponential_backoff_policy": {
+            "retry": {
+                "kind": "exponential_backoff",
                 "max_attempts": 5,
                 "min_backoff_duration": "1s",
                 "max_backoff_duration": "3s"
             }
         }"#,
-        RetryPolicyKind::Exponential(ExponentialBackoffPolicy {
-            max_attempts: NonZeroU32::new(5).unwrap(),
-            min_backoff_duration: Duration::from_secs(1),
-            max_backoff_duration: Duration::from_secs(3)})
+        get_config_with_policy!(kind = "exponent"; 5, 1, 3),
     )]
     fn test_retry_policy_deserialization_ok(
         #[case] cfg_json: &str,
-        #[case] expected_policy: RetryPolicyKind,
+        #[case] expected_config: TestCfg,
     ) {
-        let policy = serde_json::from_str::<RetryPolicyKind>(cfg_json);
-        assert!(policy.is_ok(), "Config was not deserialized properly");
-        assert_eq!(policy.unwrap(), expected_policy);
+        let cfg = serde_json::from_str::<TestCfg>(cfg_json);
+        assert!(cfg.is_ok(), "Config was not deserialized properly");
+        assert_eq!(cfg.unwrap(), expected_config);
     }
 
     #[rstest]
     #[case(
         r#"{
-            "backoff_policy": {
+            "retry": {
+                "kind": "fixed_interval",
                 "max_attempts": -1,
-                "backoff_duration": "2s"
+                "duration": "2s"
             }
         }"#,
         "invalid value: integer `-1`, expected a nonzero u32"
     )]
     #[case(
         r#"{
-            "backoff_policy": {
+            "retry": {
+                "kind": "fixed_interval",
                 "max_attempts": 0,
-                "backoff_duration": "2s"
+                "duration": "2s"
             }
         }"#,
         "invalid value: integer `0`, expected a nonzero u32"
     )]
     #[case(
         r#"{
-            "backoff_policy": {
-                "max_attempts": 1,
-                "backoff_duration": "2"
+            "retry": {
+                "kind": "fixed_interval",
+                "attempts": 1,
+                "duration": "2"
             }
         }"#,
         "invalid value: string \"2\", expected a duration"
     )]
     #[case(
         r#"{
-            "exponential_backoff_policy": {
+            "retry": {
+                "kind": "exponential_backoff",
                 "max_attempts": -1,
                 "min_backoff_duration": "2s",
                 "max_backoff_duration": "3s"
@@ -185,7 +210,8 @@ mod tests {
     )]
     #[case(
         r#"{
-            "exponential_backoff_policy": {
+            "retry": {
+                "kind": "exponential_backoff",
                 "max_attempts": 0,
                 "min_backoff_duration": "2s",
                 "max_backoff_duration": "3s"
@@ -195,17 +221,19 @@ mod tests {
     )]
     #[case(
         r#"{
-            "exponential_backoff_policy": {
+            "retry": {
+                "kind": "exponential_backoff",
                 "max_attempts": 1,
                 "min_backoff_duration": "2",
-                "max_backoff_duration": "3s"
+                "max_backoff_duration": "2s"
             }
         }"#,
         "invalid value: string \"2\", expected a duration"
     )]
     #[case(
         r#"{
-            "exponential_backoff_policy": {
+            "retry": {
+                "kind": "exponential_backoff",
                 "max_attempts": 1,
                 "min_backoff_duration": "2s",
                 "max_backoff_duration": "3"
@@ -217,14 +245,14 @@ mod tests {
         #[case] cfg_json: &str,
         #[case] expected_err_str: &str,
     ) {
-        let policy = serde_json::from_str::<RetryPolicyKind>(cfg_json);
-        assert!(policy.is_err());
-        let err_str = policy.unwrap_err().to_string();
+        let cfg = serde_json::from_str::<TestCfg>(cfg_json);
+        assert!(cfg.is_err(), "config was deserialized OK unexpectedly");
+        let err_str = cfg.unwrap_err().to_string();
         assert!(
             err_str.starts_with(expected_err_str),
             "{}",
             format!(
-                "error string '{}' should start with substring: {}",
+                "error string '{}' should start with substring: '{}'",
                 err_str, expected_err_str,
             )
         )

--- a/src/http_client/retry.rs
+++ b/src/http_client/retry.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, SystemTime};
 
 /// HTTP client retry policy kind (base or exponential)
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum RetryPolicyKind {
     /// Base backoff policy for retry
     #[serde(alias = "backoff", alias = "backoff_policy")]
@@ -19,7 +20,7 @@ pub enum RetryPolicyKind {
 
 /// HTTP client Base backoff policy for retry
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub struct BaseBackoffPolicy {
     /// Number of attempts to retry failed request
     #[serde(alias = "attempts")]
@@ -31,7 +32,7 @@ pub struct BaseBackoffPolicy {
 
 /// HTTP client Exponential backoff policy for retry
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub struct ExponentialBackoffPolicy {
     /// Number of attempts to retry failed request
     #[serde(alias = "attempts")]


### PR DESCRIPTION
Provide a possibility to include configurable Retry middleware into Http client.
- There are a 2 kinds of Middlewares based on diffenre Backoff policies: one for Base backoff policy (simple retries with fixed delay) and another one for Exponential backoff policy.
- Both Middlewares are used Default retry strategy.