### PR TITLE
Introducing extensibility points

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ retry-policies = "0.5.2"
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive", "env"] }
 rstest = "0.26"
+tokio = { version = "1.44", features = ["full", "test-util", "macros"] }
 
 [features]
 default = ["hash_argon2"]

--- a/src/builder/app.rs
+++ b/src/builder/app.rs
@@ -262,6 +262,8 @@ impl<B: AppBehavior> AppBuilder<B> {
     ///
     /// Readiness requires all registered sources to be ready; liveness requires
     /// all of them to be alive.
+    ///
+    /// Takes an `Arc` because the same instance is typically shared with the component that drives it (e.g. a task manager registered as a lifecycle participant).
     pub fn with_health_source(
         &mut self,
         source: Arc<dyn crate::probes::HealthSource>,

--- a/src/builder/app.rs
+++ b/src/builder/app.rs
@@ -105,6 +105,9 @@ pub struct AppBuilder<B> {
     metrics: Option<MetricsState>,
     /// External health sources to aggregate into service probes.
     health_sources: Vec<Arc<dyn crate::probes::HealthSource>>,
+    /// Router transforms applied inside the global layer stack (after
+    /// `RecordRequestIdLayer`), registered by `with_global_layer`.
+    global_layer_hooks: Vec<Box<dyn FnOnce(Router) -> Router + Send>>,
     /// Container of configured [`tonic`] GRPC services.
     #[cfg(feature = "grpc")]
     grpc_services: GrpcRoutesBuilder,
@@ -112,16 +115,16 @@ pub struct AppBuilder<B> {
 
 impl<B> std::fmt::Debug for AppBuilder<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AppBuilder")
-            .field("auth_provider", &self.auth_provider)
+        let mut dbg = f.debug_struct("AppBuilder");
+        dbg.field("auth_provider", &self.auth_provider)
             .field("auth_extractor", &self.auth_extractor)
             .field("config", &self.config)
             .field("metrics", &self.metrics)
-            .field(
-                "health_sources",
-                &format!("[{} source(s)]", self.health_sources.len()),
-            )
-            .finish()
+            .field("health_sources", &self.health_sources)
+            .field("global_layer_hooks", &self.global_layer_hooks.len());
+        #[cfg(feature = "grpc")]
+        dbg.field("grpc_services", &"..");
+        dbg.finish_non_exhaustive()
     }
 }
 
@@ -138,6 +141,7 @@ impl TryFrom<AppConfig> for AppBuilder<StandardAppBehavior> {
             metrics: value.metrics_state.take(),
             config: value,
             health_sources: Vec::new(),
+            global_layer_hooks: Vec::new(),
             #[cfg(feature = "grpc")]
             grpc_services: GrpcRoutes::builder(),
         })
@@ -153,6 +157,7 @@ impl Default for AppBuilder<StandardAppBehavior> {
             config: AppConfig::default(),
             metrics: None,
             health_sources: Vec::new(),
+            global_layer_hooks: Vec::new(),
             #[cfg(feature = "grpc")]
             grpc_services: GrpcRoutes::builder(),
         }
@@ -196,6 +201,7 @@ impl<B: AppBehavior> AppBuilder<B> {
             config: self.config,
             metrics: self.metrics,
             health_sources: self.health_sources,
+            global_layer_hooks: self.global_layer_hooks,
             #[cfg(feature = "grpc")]
             grpc_services: self.grpc_services,
         }
@@ -214,6 +220,21 @@ impl<B: AppBehavior> AppBuilder<B> {
     /// Normally you shouldn't use this method, relying instead on runtime configuration.
     pub fn with_auth_provider(&mut self, provider: impl AuthProvider) -> &mut Self {
         self.auth_provider = Box::new(provider);
+        self
+    }
+
+    /// Apply a transform to the application router inside the global middleware
+    /// stack. The resulting service runs *after* `RecordRequestIdLayer`, i.e.
+    /// within `CURRENT_REQUEST_ID` scope. Typical use:
+    /// `builder.with_global_layer(|r| r.layer(my_layer))`.
+    ///
+    /// Hooks are applied in registration order, innermost-first, before the
+    /// global request-id / panic-catch / header layers wrap the router.
+    pub fn with_global_layer(
+        &mut self,
+        f: impl FnOnce(Router) -> Router + Send + 'static,
+    ) -> &mut Self {
+        self.global_layer_hooks.push(Box::new(f));
         self
     }
 
@@ -412,6 +433,12 @@ impl<B: AppBehavior> AppBuilder<B> {
             rtr = rtr.merge(api_doc.build_router(auth)?);
         }
 
+        // Apply companion router transforms inside the global stack: they run
+        // after RecordRequestIdLayer (within CURRENT_REQUEST_ID scope) because
+        // wrap_global_layers wraps the already-transformed router.
+        for hook in std::mem::take(&mut self.global_layer_hooks) {
+            rtr = hook(rtr);
+        }
         // Wrap router in global layers.
         let final_rtr = self.wrap_global_layers(rtr, metrics_state);
         info!("finished building application");

--- a/src/builder/app.rs
+++ b/src/builder/app.rs
@@ -4,6 +4,7 @@ use std::{
     any::Any,
     collections::{BTreeMap, HashSet},
     convert::Infallible,
+    sync::Arc,
 };
 
 use axum::{
@@ -88,7 +89,6 @@ pub enum AppBuilderError {
 }
 
 /// Builder for application routes.
-#[derive(Debug)]
 #[non_exhaustive]
 pub struct AppBuilder<B> {
     /// Customizable application behaviors.
@@ -103,9 +103,26 @@ pub struct AppBuilder<B> {
     config: AppConfig,
     /// Metrics container object.
     metrics: Option<MetricsState>,
+    /// External health sources to aggregate into service probes.
+    health_sources: Vec<Arc<dyn crate::probes::HealthSource>>,
     /// Container of configured [`tonic`] GRPC services.
     #[cfg(feature = "grpc")]
     grpc_services: GrpcRoutesBuilder,
+}
+
+impl<B> std::fmt::Debug for AppBuilder<B> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppBuilder")
+            .field("auth_provider", &self.auth_provider)
+            .field("auth_extractor", &self.auth_extractor)
+            .field("config", &self.config)
+            .field("metrics", &self.metrics)
+            .field(
+                "health_sources",
+                &format!("[{} source(s)]", self.health_sources.len()),
+            )
+            .finish()
+    }
 }
 
 impl TryFrom<AppConfig> for AppBuilder<StandardAppBehavior> {
@@ -120,6 +137,7 @@ impl TryFrom<AppConfig> for AppBuilder<StandardAppBehavior> {
             auth_extractor,
             metrics: value.metrics_state.take(),
             config: value,
+            health_sources: Vec::new(),
             #[cfg(feature = "grpc")]
             grpc_services: GrpcRoutes::builder(),
         })
@@ -134,6 +152,7 @@ impl Default for AppBuilder<StandardAppBehavior> {
             auth_extractor: Box::new(NoOpAuthExtractor),
             config: AppConfig::default(),
             metrics: None,
+            health_sources: Vec::new(),
             #[cfg(feature = "grpc")]
             grpc_services: GrpcRoutes::builder(),
         }
@@ -176,6 +195,7 @@ impl<B: AppBehavior> AppBuilder<B> {
             auth_extractor: self.auth_extractor,
             config: self.config,
             metrics: self.metrics,
+            health_sources: self.health_sources,
             #[cfg(feature = "grpc")]
             grpc_services: self.grpc_services,
         }
@@ -235,6 +255,18 @@ impl<B: AppBehavior> AppBuilder<B> {
     {
         // TODO: maybe make state registry non-global? dubious.
         state::put(state);
+        self
+    }
+
+    /// Register an external health source aggregated into service probes.
+    ///
+    /// Readiness requires all registered sources to be ready; liveness requires
+    /// all of them to be alive.
+    pub fn with_health_source(
+        &mut self,
+        source: Arc<dyn crate::probes::HealthSource>,
+    ) -> &mut Self {
+        self.health_sources.push(source);
         self
     }
 
@@ -358,6 +390,7 @@ impl<B: AppBehavior> AppBuilder<B> {
             self.behavior.clone(),
             clone_box(self.auth_provider.as_ref()),
             clone_box(self.auth_extractor.as_ref()),
+            std::mem::take(&mut self.health_sources),
         ));
 
         // Add RapiDoc and/or OpenAPI specification generator if enabled.

--- a/src/builder/app.rs
+++ b/src/builder/app.rs
@@ -228,8 +228,10 @@ impl<B: AppBehavior> AppBuilder<B> {
     /// within `CURRENT_REQUEST_ID` scope. Typical use:
     /// `builder.with_global_layer(|r| r.layer(my_layer))`.
     ///
-    /// Hooks are applied in registration order, innermost-first, before the
-    /// global request-id / panic-catch / header layers wrap the router.
+    /// Hooks are applied in registration order, before the global request-id /
+    /// panic-catch / header layers wrap the router: the first-registered hook
+    /// becomes the innermost layer (closest to the handler), so on the request
+    /// path it runs last.
     pub fn with_global_layer(
         &mut self,
         f: impl FnOnce(Router) -> Router + Send + 'static,

--- a/src/config.rs
+++ b/src/config.rs
@@ -258,6 +258,9 @@ impl AppConfig {
     /// at [`handle()`](AppConfig::handle), composed alongside the configured
     /// subscribers before `.init()`. Useful for companion crates that observe
     /// the span/event stream (e.g. `uxum-rlog`'s capture bridge).
+    ///
+    /// Note: injected layers are consumed once at `handle()` and do not survive
+    /// a clone of the [`AppConfig`].
     pub fn with_subscriber_layer(
         &mut self,
         layer: impl tracing_subscriber::Layer<tracing_subscriber::Registry> + Send + Sync + 'static,

--- a/src/config.rs
+++ b/src/config.rs
@@ -194,6 +194,30 @@ pub struct AppConfig {
     /// Metrics state to pass into app builder.
     #[serde(skip)]
     pub metrics_state: Option<MetricsState>,
+    /// Foreign tracing-subscriber layers injected by companion crates,
+    /// composed into the registry at [`handle()`](AppConfig::handle).
+    #[serde(skip)]
+    pub extra_subscriber_layers: ExtraSubscriberLayers,
+}
+
+/// Holds injected subscriber layers. Trait objects aren't `Clone`/`Debug`;
+/// this wrapper supplies trivial impls so [`AppConfig`] keeps its derives.
+/// Cloning yields an empty set (layers are consumed once at `handle()`).
+#[derive(Default)]
+pub struct ExtraSubscriberLayers(
+    pub Vec<Box<dyn tracing_subscriber::Layer<tracing_subscriber::Registry> + Send + Sync>>,
+);
+
+impl Clone for ExtraSubscriberLayers {
+    fn clone(&self) -> Self {
+        Self(Vec::new())
+    }
+}
+
+impl std::fmt::Debug for ExtraSubscriberLayers {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ExtraSubscriberLayers({} layers)", self.0.len())
+    }
 }
 
 impl AppConfig {
@@ -227,6 +251,18 @@ impl AppConfig {
     /// Set metrics state to pass into app builder on initialization.
     pub fn with_metrics_state(&mut self, metrics_state: MetricsState) -> &mut Self {
         self.metrics_state = Some(metrics_state);
+        self
+    }
+
+    /// Inject an additional tracing-subscriber layer into the registry built
+    /// at [`handle()`](AppConfig::handle), composed alongside the configured
+    /// subscribers before `.init()`. Useful for companion crates that observe
+    /// the span/event stream (e.g. `uxum-rlog`'s capture bridge).
+    pub fn with_subscriber_layer(
+        &mut self,
+        layer: impl tracing_subscriber::Layer<tracing_subscriber::Registry> + Send + Sync + 'static,
+    ) -> &mut Self {
+        self.extra_subscriber_layers.0.push(Box::new(layer));
         self
     }
 }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -416,7 +416,9 @@ impl Handle {
 
     /// Immediately shutdown the server.
     ///
-    /// Calling this after the server tasks have already been consumed (e.g. after [`Self::wait`] returned) is a no-op that returns `Ok(())`.
+    /// Calling this after the server tasks have already been consumed (e.g. after [`Self::wait`]
+    /// returned) re-runs only the participant shutdown stages (which must be idempotent) and
+    /// returns `Ok(())`.
     ///
     /// # Errors
     ///

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -560,7 +560,8 @@ impl AppConfig {
     /// error.
     pub async fn handle(&mut self) -> Result<Handle, HandleError> {
         let token = CancellationToken::new();
-        let (registry, buf_guards) = self.logging.make_registry()?;
+        let extra_layers = std::mem::take(&mut self.extra_subscriber_layers.0);
+        let (registry, buf_guards) = self.logging.make_registry_with(extra_layers)?;
         let otel_res = self.otel_resource();
         let (tracer, tracer_provider) = if let Some(tcfg) = self.tracing.as_mut() {
             let tracer_provider = tcfg.build_provider(otel_res.clone()).await?;

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -416,6 +416,8 @@ impl Handle {
 
     /// Immediately shutdown the server.
     ///
+    /// Calling this after the server tasks have already been consumed (e.g. after [`Self::wait`] returned) is a no-op that returns `Ok(())`.
+    ///
     /// # Errors
     ///
     /// Returns `Err` if one of server tasks finished with an error.
@@ -453,6 +455,10 @@ impl Handle {
     }
 
     /// Immediately abort execution of the server.
+    ///
+    /// Unlike [`Self::graceful_shutdown`] and [`Self::wait`], this does **not**
+    /// run lifecycle participant shutdown stages. Use it only when orderly
+    /// cleanup is impossible or undesirable.
     pub fn abort(&mut self) {
         self.notify.on_shutdown();
         let server_tasks = std::mem::take(&mut self.server_tasks);

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,6 +1,6 @@
 //! Handle object to start, stop and control the service.
 
-use std::{net::SocketAddr, time::Duration};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use axum_server::{Handle as AxumHandle, service::MakeService};
 use futures::{StreamExt, TryFutureExt, stream::FuturesUnordered};
@@ -22,6 +22,7 @@ use crate::{
     config::AppConfig,
     crypto::ensure_default_crypto_provider,
     errors::IoError,
+    lifecycle::{LifecycleContext, LifecycleParticipant},
     metrics::{MetricsState, gather_runtime_metrics},
     notify::ServiceNotifier,
     signal::{SignalError, SignalStream},
@@ -68,6 +69,9 @@ pub enum HandleError {
     /// Custom error from application initialization.
     #[error("Custom error: {0}")]
     Custom(Box<dyn std::error::Error + Send + Sync>),
+    /// Error from a lifecycle participant.
+    #[error(transparent)]
+    Lifecycle(#[from] crate::lifecycle::LifecycleError),
 }
 
 impl HandleError {
@@ -81,6 +85,15 @@ impl HandleError {
     }
 }
 
+/// Shutdown stage relative to the HTTP server drain.
+#[derive(Clone, Copy, Debug)]
+enum ShutdownStage {
+    /// Before the server stops accepting / drains in-flight requests.
+    PreDrain,
+    /// After the server has fully drained.
+    PostDrain,
+}
+
 /// Handle for starting and controlling the server.
 ///
 /// Unwritten logs will be flushed when dropping this object. This might help even in case of a
@@ -90,6 +103,14 @@ impl HandleError {
 pub struct Handle {
     /// Cancellation token for auxillary tasks.
     token: CancellationToken,
+    /// Token used to request orchestrated graceful shutdown.
+    shutdown_trigger: CancellationToken,
+    /// Registered lifecycle participants.
+    participants: Vec<Arc<dyn LifecycleParticipant>>,
+    /// Application name, passed to lifecycle participants.
+    app_name: Option<String>,
+    /// Application version, passed to lifecycle participants.
+    app_version: Option<String>,
     /// Guards for [`tracing_appender::non_blocking::NonBlocking`].
     buf_guards: Vec<WorkerGuard>,
     /// Tracing pipeline.
@@ -116,6 +137,7 @@ pub struct Handle {
 
 impl Drop for Handle {
     fn drop(&mut self) {
+        self.shutdown_trigger.cancel();
         self.token.cancel();
         if let Some(provider) = self.metrics_provider.take() {
             if let Err(err) = provider.force_flush() {
@@ -137,7 +159,118 @@ impl Drop for Handle {
 }
 
 impl Handle {
+    /// Register a lifecycle participant.
+    ///
+    /// Must be called before [`Self::start`] or [`Self::run`]. Participants start
+    /// in registration order and shut down in reverse registration order.
+    pub fn register(&mut self, participant: Arc<dyn LifecycleParticipant>) -> &mut Self {
+        self.participants.push(participant);
+        self
+    }
+
+    /// Token that, when cancelled, initiates orchestrated graceful shutdown.
+    #[must_use]
+    pub fn shutdown_trigger(&self) -> CancellationToken {
+        self.shutdown_trigger.clone()
+    }
+
+    /// Create the context passed to lifecycle participants.
+    fn lifecycle_context(&self) -> LifecycleContext {
+        let mut ctx = LifecycleContext::new(self.token.clone(), self.shutdown_trigger.clone());
+        if let Some(name) = &self.app_name {
+            ctx = ctx.with_app_name(name);
+        }
+        if let Some(version) = &self.app_version {
+            ctx = ctx.with_app_version(version);
+        }
+        ctx
+    }
+
+    /// Spawn a task converting shutdown signals into a shutdown request.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if a signal handler fails to register.
+    fn spawn_signal_handler(&self) -> Result<JoinHandle<()>, HandleError> {
+        let span = debug_span!("signal_handler");
+        let mut sig = SignalStream::new()?;
+        let trigger = self.shutdown_trigger.clone();
+        Ok(tokio::spawn(
+            async move {
+                loop {
+                    tokio::select! {
+                        () = trigger.cancelled() => break,
+                        next = sig.next() => match next {
+                            Ok(sig) if sig.is_shutdown() => {
+                                info!("received {}, initiating graceful shutdown", sig.name());
+                                trigger.cancel();
+                                break;
+                            }
+                            Ok(sig) => {
+                                debug!("don't know what to do with signal {}, ignoring", sig.name());
+                            }
+                            Err(err) => {
+                                error!("error in signal handler: {err}");
+                            }
+                        }
+                    }
+                }
+            }
+            .instrument(span),
+        ))
+    }
+
+    /// Run one shutdown stage over all participants, in reverse registration order.
+    ///
+    /// Errors are logged and do not interrupt the sequence.
+    async fn run_shutdown_stage(&self, stage: ShutdownStage) {
+        let ctx = self.lifecycle_context();
+        for participant in self.participants.iter().rev() {
+            debug!(
+                participant = participant.name(),
+                "shutting down ({stage:?})"
+            );
+            let res = match stage {
+                ShutdownStage::PreDrain => participant.shutdown_pre_drain(&ctx).await,
+                ShutdownStage::PostDrain => participant.shutdown_post_drain(&ctx).await,
+            };
+            if let Err(err) = res {
+                error!(
+                    participant = participant.name(),
+                    "error during shutdown ({stage:?}): {err}"
+                );
+            }
+        }
+    }
+
+    /// Best-effort unwind of partially started participants (both stages, reverse order).
+    async fn unwind_participants(
+        participants: &[Arc<dyn LifecycleParticipant>],
+        ctx: &LifecycleContext,
+    ) {
+        for participant in participants.iter().rev() {
+            if let Err(err) = participant.shutdown_pre_drain(ctx).await {
+                error!(
+                    participant = participant.name(),
+                    "error during unwind: {err}"
+                );
+            }
+        }
+        for participant in participants.iter().rev() {
+            if let Err(err) = participant.shutdown_post_drain(ctx).await {
+                error!(
+                    participant = participant.name(),
+                    "error during unwind: {err}"
+                );
+            }
+        }
+    }
+
     /// Set up background service tasks.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if signal handler registration fails.
     fn prepare(&mut self) -> Result<(), HandleError> {
         if self.signal_handler.is_none() {
             let signal_handler = match self.spawn_signal_handler() {
@@ -155,41 +288,11 @@ impl Handle {
         Ok(())
     }
 
-    /// Launch a task that captures common UNIX signals.
-    ///
-    /// This will gracefully shut down all servers if signal type is appropriate.
+    /// Start axum server tasks.
     ///
     /// # Errors
     ///
-    /// Returns `Err` if some signal handler failed to register.
-    fn spawn_signal_handler(&self) -> Result<JoinHandle<()>, HandleError> {
-        let span = debug_span!("signal_handler");
-        let mut sig = SignalStream::new()?;
-        let handle = self.handle.clone();
-        Ok(tokio::spawn(
-            async move {
-                loop {
-                    match sig.next().await {
-                        Ok(sig) if sig.is_shutdown() => {
-                            info!("received {}, shutting down server", sig.name());
-                            // FIXME: configure duration.
-                            handle.graceful_shutdown(Some(Duration::from_secs(5)));
-                            break;
-                        }
-                        Ok(sig) => {
-                            debug!("don't know what to do with signal {}, ignoring", sig.name());
-                        }
-                        Err(err) => {
-                            error!("error in signal handler: {err}");
-                        }
-                    }
-                }
-            }
-            .instrument(span),
-        ))
-    }
-
-    /// Start axum server tasks.
+    /// Returns `Err` if a server fails to bind or start.
     async fn start_servers<A>(
         &mut self,
         servers: Vec<ServerBuilder>,
@@ -260,11 +363,18 @@ impl Handle {
         Ok(())
     }
 
-    /// Start the server in the background.
+    /// Start the server in the background, running lifecycle participants around the listen point.
+    ///
+    /// Participants are started in registration order before the server begins listening
+    /// (`start_pre_listen`), and again after it is accepting connections (`start_post_listen`).
+    /// On failure, already-started participants are unwound via both shutdown stages.
     ///
     /// # Errors
     ///
-    /// Returns `Err` if caught an error when initializing server tasks.
+    /// Returns `Err` if:
+    /// * Signal handler registration fails.
+    /// * A lifecycle participant fails to start.
+    /// * Server tasks fail to initialize.
     pub async fn start<A>(&mut self, servers: Vec<ServerBuilder>, app: A) -> Result<(), HandleError>
     where
         A: MakeService<SocketAddr, http::Request<hyper::body::Incoming>>
@@ -276,7 +386,30 @@ impl Handle {
         A::MakeFuture: Send,
     {
         self.prepare()?;
-        self.start_servers(servers, app).await?;
+        let ctx = self.lifecycle_context();
+        let mut started = 0_usize;
+        for participant in &self.participants {
+            debug!(participant = participant.name(), "starting (pre-listen)");
+            if let Err(err) = participant.start_pre_listen(&ctx).await {
+                error!(participant = participant.name(), "failed to start: {err}");
+                Self::unwind_participants(&self.participants[..started], &ctx).await;
+                return Err(err.into());
+            }
+            started += 1;
+        }
+        if let Err(err) = self.start_servers(servers, app).await {
+            Self::unwind_participants(&self.participants[..started], &ctx).await;
+            return Err(err);
+        }
+        for participant in &self.participants {
+            debug!(participant = participant.name(), "starting (post-listen)");
+            if let Err(err) = participant.start_post_listen(&ctx).await {
+                error!(participant = participant.name(), "failed to start: {err}");
+                self.abort();
+                Self::unwind_participants(&self.participants, &ctx).await;
+                return Err(err.into());
+            }
+        }
         self.notify.on_ready();
         Ok(())
     }
@@ -287,16 +420,26 @@ impl Handle {
     ///
     /// Returns `Err` if one of server tasks finished with an error.
     pub async fn shutdown(&mut self) -> Result<(), HandleError> {
+        self.shutdown_trigger.cancel();
         self.notify.on_shutdown();
+        self.run_shutdown_stage(ShutdownStage::PreDrain).await;
         self.handle.shutdown();
+        let mut result: Result<(), HandleError> = Ok(());
         let server_tasks = std::mem::take(&mut self.server_tasks);
         for res in futures::future::join_all(server_tasks).await {
-            res??;
+            let task_result = res.map_err(HandleError::from).and_then(|inner| inner);
+            if result.is_ok() {
+                result = task_result;
+            }
         }
-        Ok(())
+        self.run_shutdown_stage(ShutdownStage::PostDrain).await;
+        result
     }
 
     /// Gracefully shutdown the server, waiting for in-progress requests to finish.
+    ///
+    /// Triggers orchestrated shutdown: pre-drain lifecycle hooks run, then the HTTP
+    /// server drains, then post-drain lifecycle hooks run.
     ///
     /// # Errors
     ///
@@ -305,13 +448,8 @@ impl Handle {
         &mut self,
         graceful: Option<Duration>,
     ) -> Result<(), HandleError> {
-        self.notify.on_shutdown();
-        self.handle.graceful_shutdown(graceful);
-        let server_tasks = std::mem::take(&mut self.server_tasks);
-        for res in futures::future::join_all(server_tasks).await {
-            res??;
-        }
-        Ok(())
+        self.shutdown_trigger.cancel();
+        self.wait(graceful).await
     }
 
     /// Immediately abort execution of the server.
@@ -323,14 +461,14 @@ impl Handle {
         }
     }
 
-    /// Start the server and block execution until one of the server tasks exits.
-    ///
-    /// Will gracefully shutdown remaining server tasks.
+    /// Start the server and block execution until one of the server tasks exits or shutdown is
+    /// requested. Runs all lifecycle shutdown stages around the HTTP server drain.
     ///
     /// # Errors
     ///
     /// Returns `Err` if:
-    /// * Caught an error when initializing server tasks.
+    /// * Signal handler registration fails.
+    /// * A lifecycle participant fails to start.
     /// * One of server tasks finished with an error.
     pub async fn run<A>(
         &mut self,
@@ -351,9 +489,8 @@ impl Handle {
         self.wait(graceful).await
     }
 
-    /// Block execution until one of the server tasks exits.
-    ///
-    /// Will gracefully shutdown remaining server tasks.
+    /// Block execution until shutdown is requested or a server task exits, then run the
+    /// orchestrated shutdown sequence (pre-drain hooks → HTTP drain → post-drain hooks).
     ///
     /// # Errors
     ///
@@ -364,19 +501,29 @@ impl Handle {
         }
         let server_tasks = std::mem::take(&mut self.server_tasks);
         let mut tasks: FuturesUnordered<_> = server_tasks.into_iter().collect();
-        match tasks.next().await {
-            // Gracefully shutdown other tasks and return result of the one which exited
-            // first.
-            Some(ret) => {
-                self.handle.graceful_shutdown(graceful);
-                while let Some(other_ret) = tasks.next().await {
-                    let _ = other_ret?;
+        let mut result: Result<(), HandleError> = Ok(());
+        tokio::select! {
+            () = self.shutdown_trigger.cancelled() => {}
+            res = tasks.next() => {
+                // A server task exited on its own; record its result and shut
+                // everything else down.
+                if let Some(res) = res {
+                    result = res.map_err(HandleError::from).and_then(|inner| inner);
                 }
-                ret?
+                self.shutdown_trigger.cancel();
             }
-            // This should not happen normally.
-            None => Ok(()),
         }
+        self.notify.on_shutdown();
+        self.run_shutdown_stage(ShutdownStage::PreDrain).await;
+        self.handle.graceful_shutdown(graceful);
+        while let Some(res) = tasks.next().await {
+            let task_result = res.map_err(HandleError::from).and_then(|inner| inner);
+            if result.is_ok() {
+                result = task_result;
+            }
+        }
+        self.run_shutdown_stage(ShutdownStage::PostDrain).await;
+        result
     }
 
     /// Send custom status update notification to process supervisor.
@@ -443,6 +590,10 @@ impl AppConfig {
         let notify = ServiceNotifier::new();
         Ok(Handle {
             token,
+            shutdown_trigger: CancellationToken::new(),
+            participants: Vec::new(),
+            app_name: self.app_name.clone(),
+            app_version: self.app_version.clone(),
             buf_guards,
             tracer,
             tracer_provider,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ pub use self::{
         AdditionalMetricLabels, MetricsBuilder, MetricsError, MetricsState, text_exporter::*,
     },
     notify::ServiceNotifier,
-    probes::{ProbeConfig, ProbeState},
+    probes::{HealthSource, ProbeConfig, ProbeState},
     response::{GetResponseSchemas, ResponseSchema},
     runtime::{RuntimeConfig, RuntimeError},
     signal::{SignalError, SignalStream},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod http_client;
 #[cfg(feature = "kafka")]
 mod kafka;
 mod layers;
+mod lifecycle;
 mod logging;
 mod metrics;
 mod notify;
@@ -61,6 +62,7 @@ pub use self::{
         request_id::CURRENT_REQUEST_ID,
         timeout::{CURRENT_DEADLINE, HandlerTimeoutConfig, TimeoutError},
     },
+    lifecycle::{LifecycleContext, LifecycleError, LifecycleParticipant},
     logging::LoggingConfig,
     metrics::{
         AdditionalMetricLabels, MetricsBuilder, MetricsError, MetricsState, text_exporter::*,

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -54,6 +54,10 @@ impl LifecycleError {
 #[derive(Clone, Debug)]
 pub struct LifecycleContext {
     /// Root cancellation token of the service.
+    ///
+    /// Cancelled when the service is finally torn down. Deliberately NOT a child
+    /// of the shutdown trigger: requesting graceful shutdown must not cancel
+    /// running tasks outright, since they are stopped in an orchestrated order.
     root_token: CancellationToken,
     /// Trigger used to request service-wide graceful shutdown.
     shutdown_trigger: CancellationToken,
@@ -80,15 +84,15 @@ impl LifecycleContext {
 
     /// Set application name.
     #[must_use]
-    pub fn with_app_name(mut self, name: impl Into<String>) -> Self {
-        self.app_name = Some(name.into());
+    pub fn with_app_name(mut self, name: impl ToString) -> Self {
+        self.app_name = Some(name.to_string());
         self
     }
 
     /// Set application version.
     #[must_use]
-    pub fn with_app_version(mut self, version: impl Into<String>) -> Self {
-        self.app_version = Some(version.into());
+    pub fn with_app_version(mut self, version: impl ToString) -> Self {
+        self.app_version = Some(version.to_string());
         self
     }
 
@@ -140,24 +144,42 @@ pub trait LifecycleParticipant: Send + Sync + 'static {
     fn name(&self) -> &str;
 
     /// Called before the HTTP server starts listening.
-    async fn start_pre_listen(&self, ctx: &LifecycleContext) -> Result<(), LifecycleError> {
-        let _ = ctx;
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LifecycleError::Start`] if this participant fails to start.
+    /// Startup is aborted and already-started participants are unwound.
+    async fn start_pre_listen(&self, _ctx: &LifecycleContext) -> Result<(), LifecycleError> {
         Ok(())
     }
 
     /// Called after the HTTP server is accepting connections.
-    async fn start_post_listen(&self, ctx: &LifecycleContext) -> Result<(), LifecycleError> {
-        let _ = ctx;
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LifecycleError::Start`] if this participant fails to start.
+    /// Startup is aborted and already-started participants are unwound.
+    async fn start_post_listen(&self, _ctx: &LifecycleContext) -> Result<(), LifecycleError> {
         Ok(())
     }
 
     /// Called when shutdown begins, before the HTTP server graceful drain.
-    async fn shutdown_pre_drain(&self) -> Result<(), LifecycleError> {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LifecycleError::Shutdown`] if this participant fails to shut down
+    /// cleanly. The orchestrator logs such errors and continues the sequence.
+    async fn shutdown_pre_drain(&self, _ctx: &LifecycleContext) -> Result<(), LifecycleError> {
         Ok(())
     }
 
     /// Called after the HTTP server finished draining, before telemetry flush.
-    async fn shutdown_post_drain(&self) -> Result<(), LifecycleError> {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LifecycleError::Shutdown`] if this participant fails to shut down
+    /// cleanly. The orchestrator logs such errors and continues the sequence.
+    async fn shutdown_post_drain(&self, _ctx: &LifecycleContext) -> Result<(), LifecycleError> {
         Ok(())
     }
 }
@@ -181,8 +203,8 @@ mod tests {
         let ctx = LifecycleContext::new(CancellationToken::new(), CancellationToken::new());
         assert!(p.start_pre_listen(&ctx).await.is_ok());
         assert!(p.start_post_listen(&ctx).await.is_ok());
-        assert!(p.shutdown_pre_drain().await.is_ok());
-        assert!(p.shutdown_post_drain().await.is_ok());
+        assert!(p.shutdown_pre_drain(&ctx).await.is_ok());
+        assert!(p.shutdown_post_drain(&ctx).await.is_ok());
     }
 
     #[test]

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -1,0 +1,201 @@
+//! Generic service lifecycle participation API.
+//!
+//! Companion crates (e.g. `uxum-tasks`) implement [`LifecycleParticipant`] to have
+//! their startup and shutdown orchestrated by [`crate::Handle`], ordered around the
+//! HTTP server's listen and drain points.
+//!
+//! Orchestrated sequence, as driven by [`crate::Handle::run`]:
+//!
+//! 1. [`LifecycleParticipant::start_pre_listen`] (registration order)
+//! 2. HTTP server starts listening
+//! 3. [`LifecycleParticipant::start_post_listen`] (registration order)
+//! 4. … service runs until shutdown is requested …
+//! 5. [`LifecycleParticipant::shutdown_pre_drain`] (reverse registration order)
+//! 6. HTTP server graceful drain
+//! 7. [`LifecycleParticipant::shutdown_post_drain`] (reverse registration order)
+
+use async_trait::async_trait;
+use thiserror::Error;
+use tokio_util::sync::CancellationToken;
+
+/// Error type returned by lifecycle participants.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum LifecycleError {
+    /// Participant failed to start.
+    #[error("Lifecycle participant failed to start: {0}")]
+    Start(Box<dyn std::error::Error + Send + Sync>),
+    /// Participant failed to shut down cleanly.
+    #[error("Lifecycle participant failed to shut down: {0}")]
+    Shutdown(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl LifecycleError {
+    /// Wrap a custom startup error.
+    #[must_use]
+    pub fn start<T>(err: T) -> Self
+    where
+        T: Into<Box<dyn std::error::Error + Send + Sync>>,
+    {
+        Self::Start(err.into())
+    }
+
+    /// Wrap a custom shutdown error.
+    #[must_use]
+    pub fn shutdown<T>(err: T) -> Self
+    where
+        T: Into<Box<dyn std::error::Error + Send + Sync>>,
+    {
+        Self::Shutdown(err.into())
+    }
+}
+
+/// Context passed to lifecycle participants during startup.
+#[derive(Clone, Debug)]
+pub struct LifecycleContext {
+    /// Root cancellation token of the service.
+    root_token: CancellationToken,
+    /// Trigger used to request service-wide graceful shutdown.
+    shutdown_trigger: CancellationToken,
+    /// Application name, if configured.
+    app_name: Option<String>,
+    /// Application version, if configured.
+    app_version: Option<String>,
+}
+
+impl LifecycleContext {
+    /// Create a new lifecycle context.
+    ///
+    /// Normally constructed by [`crate::Handle`]. Public so participants can be
+    /// driven directly in tests or from other frameworks.
+    #[must_use]
+    pub fn new(root_token: CancellationToken, shutdown_trigger: CancellationToken) -> Self {
+        Self {
+            root_token,
+            shutdown_trigger,
+            app_name: None,
+            app_version: None,
+        }
+    }
+
+    /// Set application name.
+    #[must_use]
+    pub fn with_app_name(mut self, name: impl Into<String>) -> Self {
+        self.app_name = Some(name.into());
+        self
+    }
+
+    /// Set application version.
+    #[must_use]
+    pub fn with_app_version(mut self, version: impl Into<String>) -> Self {
+        self.app_version = Some(version.into());
+        self
+    }
+
+    /// Root cancellation token; cancelled when the service is torn down.
+    #[must_use]
+    pub fn root_token(&self) -> &CancellationToken {
+        &self.root_token
+    }
+
+    /// Request service-wide graceful shutdown.
+    ///
+    /// Idempotent; safe to call from any task at any time after startup.
+    pub fn request_shutdown(&self) {
+        self.shutdown_trigger.cancel();
+    }
+
+    /// Whether service-wide shutdown has been requested.
+    #[must_use]
+    pub fn is_shutdown_requested(&self) -> bool {
+        self.shutdown_trigger.is_cancelled()
+    }
+
+    /// Application name, if configured.
+    #[must_use]
+    pub fn app_name(&self) -> Option<&str> {
+        self.app_name.as_deref()
+    }
+
+    /// Application version, if configured.
+    #[must_use]
+    pub fn app_version(&self) -> Option<&str> {
+        self.app_version.as_deref()
+    }
+}
+
+/// A component whose startup and shutdown is orchestrated by [`crate::Handle`].
+///
+/// All methods have default no-op implementations. Implementations must tolerate
+/// shutdown stages being invoked after a partial start (e.g. when another
+/// participant failed during startup and the already-started ones are unwound):
+/// `shutdown_pre_drain` and `shutdown_post_drain` may run even if only
+/// `start_pre_listen` succeeded.
+///
+/// Shutdown-stage errors are logged by the orchestrator and do not stop the
+/// shutdown sequence.
+#[async_trait]
+pub trait LifecycleParticipant: Send + Sync + 'static {
+    /// Participant name, used in logs.
+    fn name(&self) -> &str;
+
+    /// Called before the HTTP server starts listening.
+    async fn start_pre_listen(&self, ctx: &LifecycleContext) -> Result<(), LifecycleError> {
+        let _ = ctx;
+        Ok(())
+    }
+
+    /// Called after the HTTP server is accepting connections.
+    async fn start_post_listen(&self, ctx: &LifecycleContext) -> Result<(), LifecycleError> {
+        let _ = ctx;
+        Ok(())
+    }
+
+    /// Called when shutdown begins, before the HTTP server graceful drain.
+    async fn shutdown_pre_drain(&self) -> Result<(), LifecycleError> {
+        Ok(())
+    }
+
+    /// Called after the HTTP server finished draining, before telemetry flush.
+    async fn shutdown_post_drain(&self) -> Result<(), LifecycleError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Minimal;
+
+    #[async_trait]
+    impl LifecycleParticipant for Minimal {
+        fn name(&self) -> &str {
+            "minimal"
+        }
+    }
+
+    #[tokio::test]
+    async fn default_methods_are_noop_ok() {
+        let p = Minimal;
+        let ctx = LifecycleContext::new(CancellationToken::new(), CancellationToken::new());
+        assert!(p.start_pre_listen(&ctx).await.is_ok());
+        assert!(p.start_post_listen(&ctx).await.is_ok());
+        assert!(p.shutdown_pre_drain().await.is_ok());
+        assert!(p.shutdown_post_drain().await.is_ok());
+    }
+
+    #[test]
+    fn request_shutdown_cancels_trigger() {
+        let trigger = CancellationToken::new();
+        let ctx = LifecycleContext::new(CancellationToken::new(), trigger.clone())
+            .with_app_name("app")
+            .with_app_version("1.0");
+        assert!(!ctx.is_shutdown_requested());
+        ctx.request_shutdown();
+        assert!(trigger.is_cancelled());
+        assert!(ctx.is_shutdown_requested());
+        assert_eq!(ctx.app_name(), Some("app"));
+        assert_eq!(ctx.app_version(), Some("1.0"));
+    }
+}

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -54,8 +54,22 @@ impl LoggingConfig {
     ///
     /// Returns `Err` if any of the subscribers cannot be initialized.
     pub fn make_registry(&self) -> Result<(LoggingRegistry, Vec<WorkerGuard>), LoggingError> {
+        self.make_registry_with(Vec::new())
+    }
+
+    /// Like [`make_registry`](Self::make_registry), but additionally composes
+    /// `extra` foreign layers (e.g. a companion crate's capture bridge) into
+    /// the registry alongside the configured subscribers, before `.init()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if any of the subscribers cannot be initialized.
+    pub fn make_registry_with(
+        &self,
+        extra: Vec<Box<dyn Layer<Registry> + Send + Sync>>,
+    ) -> Result<(LoggingRegistry, Vec<WorkerGuard>), LoggingError> {
         let num_subs = self.subscribers.len();
-        let (subs, buf_guards) = self.subscribers.iter().try_fold(
+        let (mut subs, buf_guards) = self.subscribers.iter().try_fold(
             (Vec::with_capacity(num_subs), Vec::with_capacity(num_subs)),
             |(mut acc_s, mut acc_g), sub_cfg| {
                 let (sub, guard) = sub_cfg.make_layer()?;
@@ -64,6 +78,7 @@ impl LoggingConfig {
                 Ok::<_, LoggingError>((acc_s, acc_g))
             },
         )?;
+        subs.extend(extra);
         Ok((Registry::default().with(subs), buf_guards))
     }
 }

--- a/src/probes.rs
+++ b/src/probes.rs
@@ -214,7 +214,7 @@ impl<B> ProbeStateInner<B> {
 
     /// Aggregate liveness over the watchdog and all health sources.
     pub(crate) fn is_alive(&self) -> bool {
-        self.watchdog.as_ref().map_or(true, Watchdog::is_alive)
+        self.watchdog.as_ref().is_none_or(Watchdog::is_alive)
             && self.health_sources.iter().all(|src| src.is_alive())
     }
 }

--- a/src/probes.rs
+++ b/src/probes.rs
@@ -31,7 +31,7 @@ use crate::{
 /// Register implementations via `AppBuilder::with_health_source`. All registered
 /// sources are AND-ed together with the built-in maintenance flag (readiness) and
 /// runtime watchdog (liveness).
-pub trait HealthSource: Send + Sync + 'static {
+pub trait HealthSource: std::fmt::Debug + Send + Sync + 'static {
     /// Source name, used in logs.
     fn name(&self) -> &str;
 
@@ -206,13 +206,14 @@ pub struct ProbeStateInner<B> {
 
 impl<B> ProbeStateInner<B> {
     /// Aggregate readiness over the maintenance flag and all health sources.
-    pub fn is_ready(&self) -> bool {
+    pub(crate) fn is_ready(&self) -> bool {
+        // Relaxed: probes are polled independently; no cross-location ordering to protect.
         !self.in_maintenance.load(Ordering::Relaxed)
             && self.health_sources.iter().all(|src| src.is_ready())
     }
 
     /// Aggregate liveness over the watchdog and all health sources.
-    pub fn is_alive(&self) -> bool {
+    pub(crate) fn is_alive(&self) -> bool {
         self.watchdog.as_ref().map_or(true, Watchdog::is_alive)
             && self.health_sources.iter().all(|src| src.is_alive())
     }
@@ -260,6 +261,7 @@ mod tests {
 
     use super::*;
 
+    #[derive(Debug)]
     struct FakeSource {
         ready: AtomicBool,
         alive: AtomicBool,

--- a/src/probes.rs
+++ b/src/probes.rs
@@ -26,6 +26,26 @@ use crate::{
     watchdog::{Watchdog, WatchdogConfig},
 };
 
+/// Pluggable health source feeding service probes.
+///
+/// Register implementations via `AppBuilder::with_health_source`. All registered
+/// sources are AND-ed together with the built-in maintenance flag (readiness) and
+/// runtime watchdog (liveness).
+pub trait HealthSource: Send + Sync + 'static {
+    /// Source name, used in logs.
+    fn name(&self) -> &str;
+
+    /// Whether the component is ready to serve traffic (readiness probe).
+    fn is_ready(&self) -> bool {
+        true
+    }
+
+    /// Whether the component is functioning at all (liveness probe).
+    fn is_alive(&self) -> bool {
+        true
+    }
+}
+
 /// Configuration for service probes and management mode API.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[non_exhaustive]
@@ -97,10 +117,16 @@ impl ProbeConfig {
         behavior: B,
         auth_provider: Box<dyn AuthProvider>,
         auth_extractor: Box<dyn AuthExtractor>,
+        health_sources: Vec<Arc<dyn HealthSource>>,
     ) -> Router {
         // TODO: add toggle for probes, and possibly for maintenance mode.
         let _span = debug_span!("build_probes").entered();
-        let state = ProbeState::new(behavior, self.start_in_maintenance, self.watchdog.as_ref());
+        let state = ProbeState::new(
+            behavior,
+            self.start_in_maintenance,
+            self.watchdog.as_ref(),
+            health_sources,
+        );
         Router::new()
             .route(&self.readiness_path, routing::get(readiness_probe))
             .route(&self.liveness_path, routing::get(liveness_probe))
@@ -140,14 +166,20 @@ impl Default for ProbeState<StandardAppBehavior> {
             behavior: StandardAppBehavior,
             in_maintenance: AtomicBool::new(true),
             watchdog: None,
+            health_sources: Vec::new(),
         }))
     }
 }
 
 impl<B> ProbeState<B> {
-    /// Create new [`ProbeState`] with optional [`WatchdogConfig`].
+    /// Create new [`ProbeState`] with optional [`WatchdogConfig`] and external health sources.
     #[must_use]
-    pub fn new(behavior: B, in_maint: bool, watchdog: Option<&WatchdogConfig>) -> Self {
+    pub fn new(
+        behavior: B,
+        in_maint: bool,
+        watchdog: Option<&WatchdogConfig>,
+        health_sources: Vec<Arc<dyn HealthSource>>,
+    ) -> Self {
         Self(Arc::new(ProbeStateInner {
             behavior,
             in_maintenance: AtomicBool::new(in_maint),
@@ -156,6 +188,7 @@ impl<B> ProbeState<B> {
                 watchdog.start();
                 watchdog
             }),
+            health_sources,
         }))
     }
 }
@@ -167,15 +200,31 @@ pub struct ProbeStateInner<B> {
     in_maintenance: AtomicBool,
     /// Optional runtime watchdog for use in liveness probes.
     watchdog: Option<Watchdog>,
+    /// External health sources aggregated into probe responses.
+    health_sources: Vec<Arc<dyn HealthSource>>,
+}
+
+impl<B> ProbeStateInner<B> {
+    /// Aggregate readiness over the maintenance flag and all health sources.
+    pub fn is_ready(&self) -> bool {
+        !self.in_maintenance.load(Ordering::Relaxed)
+            && self.health_sources.iter().all(|src| src.is_ready())
+    }
+
+    /// Aggregate liveness over the watchdog and all health sources.
+    pub fn is_alive(&self) -> bool {
+        self.watchdog.as_ref().map_or(true, Watchdog::is_alive)
+            && self.health_sources.iter().all(|src| src.is_alive())
+    }
 }
 
 /// Readiness probe handler.
 ///
 /// For use in k8s-like deployments.
 async fn readiness_probe<B: AppBehavior>(state: State<ProbeState<B>>) -> Response {
-    match state.in_maintenance.load(Ordering::Relaxed) {
-        true => StatusCode::SERVICE_UNAVAILABLE.into_response(),
-        false => state.behavior.readiness_probe().await.into_response(),
+    match state.is_ready() {
+        true => state.behavior.readiness_probe().await.into_response(),
+        false => StatusCode::SERVICE_UNAVAILABLE.into_response(),
     }
 }
 
@@ -183,12 +232,9 @@ async fn readiness_probe<B: AppBehavior>(state: State<ProbeState<B>>) -> Respons
 ///
 /// For use in k8s-like deployments.
 async fn liveness_probe<B: AppBehavior>(state: State<ProbeState<B>>) -> Response {
-    match &state.watchdog {
-        Some(watchdog) => match watchdog.is_alive() {
-            true => state.behavior.liveness_probe().await.into_response(),
-            false => StatusCode::SERVICE_UNAVAILABLE.into_response(),
-        },
-        None => state.behavior.liveness_probe().await.into_response(),
+    match state.is_alive() {
+        true => state.behavior.liveness_probe().await.into_response(),
+        false => StatusCode::SERVICE_UNAVAILABLE.into_response(),
     }
 }
 
@@ -206,4 +252,82 @@ async fn maintenance_off<B>(state: State<ProbeState<B>>) -> impl IntoResponse {
         info!("maintenance mode disabled");
     }
     StatusCode::OK
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::*;
+
+    struct FakeSource {
+        ready: AtomicBool,
+        alive: AtomicBool,
+    }
+
+    impl FakeSource {
+        fn new(ready: bool, alive: bool) -> Arc<Self> {
+            Arc::new(Self {
+                ready: AtomicBool::new(ready),
+                alive: AtomicBool::new(alive),
+            })
+        }
+    }
+
+    impl HealthSource for FakeSource {
+        fn name(&self) -> &str {
+            "fake"
+        }
+        fn is_ready(&self) -> bool {
+            self.ready.load(Ordering::Relaxed)
+        }
+        fn is_alive(&self) -> bool {
+            self.alive.load(Ordering::Relaxed)
+        }
+    }
+
+    #[test]
+    fn readiness_aggregates_sources_and_maintenance() {
+        let src = FakeSource::new(true, true);
+        let state = ProbeState::new(
+            StandardAppBehavior,
+            false,
+            None,
+            vec![src.clone() as Arc<dyn HealthSource>],
+        );
+        assert!(state.is_ready());
+        src.ready.store(false, Ordering::Relaxed);
+        assert!(!state.is_ready());
+        // Maintenance overrides even ready sources.
+        src.ready.store(true, Ordering::Relaxed);
+        let state = ProbeState::new(
+            StandardAppBehavior,
+            true,
+            None,
+            vec![src as Arc<dyn HealthSource>],
+        );
+        assert!(!state.is_ready());
+    }
+
+    #[test]
+    fn liveness_aggregates_sources() {
+        let src = FakeSource::new(true, true);
+        // No watchdog: liveness depends only on sources.
+        let state = ProbeState::new(
+            StandardAppBehavior,
+            false,
+            None,
+            vec![src.clone() as Arc<dyn HealthSource>],
+        );
+        assert!(state.is_alive());
+        src.alive.store(false, Ordering::Relaxed);
+        assert!(!state.is_alive());
+    }
+
+    #[test]
+    fn no_sources_preserves_old_behavior() {
+        let state = ProbeState::new(StandardAppBehavior, false, None, Vec::new());
+        assert!(state.is_ready());
+        assert!(state.is_alive());
+    }
 }

--- a/tests/extra_layer.rs
+++ b/tests/extra_layer.rs
@@ -1,0 +1,46 @@
+//! PR1: a tracing-subscriber layer injected via `AppConfig::with_subscriber_layer`
+//! observes events emitted after the registry is initialized.
+
+use std::sync::{Arc, Mutex};
+
+use tracing::Subscriber;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::Layer;
+use uxum::AppConfig;
+
+/// Records the target of each event it sees.
+#[derive(Clone, Default)]
+struct ProbeLayer {
+    events: Arc<Mutex<Vec<String>>>,
+}
+
+impl<S> Layer<S> for ProbeLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        self.events
+            .lock()
+            .unwrap()
+            .push(event.metadata().target().to_string());
+    }
+}
+
+#[tokio::test]
+async fn injected_layer_observes_events() {
+    let probe = ProbeLayer::default();
+    let seen = probe.events.clone();
+
+    let mut app = AppConfig::default();
+    app.with_subscriber_layer(probe);
+    // handle() builds and `.init()`s the registry, installing the probe layer.
+    let _handle = app.handle().await.expect("handle");
+
+    tracing::info!(target: "pr1_probe", "hello");
+    assert!(
+        seen.lock().unwrap().iter().any(|t| t == "pr1_probe"),
+        "probe layer did not observe the event; saw: {:?}",
+        seen.lock().unwrap()
+    );
+}

--- a/tests/extra_layer.rs
+++ b/tests/extra_layer.rs
@@ -1,12 +1,12 @@
-//! PR1: a tracing-subscriber layer injected via `AppConfig::with_subscriber_layer`
+//! A tracing-subscriber layer injected via `AppConfig::with_subscriber_layer`
 //! observes events emitted after the registry is initialized.
 
 use std::sync::{Arc, Mutex};
 
 use tracing::Subscriber;
+use tracing_subscriber::Layer;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::registry::LookupSpan;
-use tracing_subscriber::Layer;
 use uxum::AppConfig;
 
 /// Records the target of each event it sees.

--- a/tests/global_layer.rs
+++ b/tests/global_layer.rs
@@ -1,4 +1,4 @@
-//! PR2: a layer injected via `AppBuilder::with_global_layer` runs inside the
+//! A layer injected via `AppBuilder::with_global_layer` runs inside the
 //! `CURRENT_REQUEST_ID` task-local scope (i.e. after RecordRequestIdLayer).
 
 use std::sync::{Arc, Mutex};
@@ -39,9 +39,8 @@ where
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<S::Response, S::Error>> + Send>,
-    >;
+    type Future =
+        std::pin::Pin<Box<dyn std::future::Future<Output = Result<S::Response, S::Error>> + Send>>;
 
     fn poll_ready(
         &mut self,

--- a/tests/global_layer.rs
+++ b/tests/global_layer.rs
@@ -1,0 +1,89 @@
+//! PR2: a layer injected via `AppBuilder::with_global_layer` runs inside the
+//! `CURRENT_REQUEST_ID` task-local scope (i.e. after RecordRequestIdLayer).
+
+use std::sync::{Arc, Mutex};
+
+use axum::body::Body;
+use axum::http::Request;
+use tower::{Layer, Service, ServiceExt};
+use uxum::CURRENT_REQUEST_ID;
+use uxum::{AppBuilder, AppConfig};
+
+/// A tower layer whose service reads CURRENT_REQUEST_ID and records whether it
+/// was in scope.
+#[derive(Clone)]
+struct ProbeLayer {
+    saw_scope: Arc<Mutex<bool>>,
+}
+
+impl<S> Layer<S> for ProbeLayer {
+    type Service = ProbeService<S>;
+    fn layer(&self, inner: S) -> Self::Service {
+        ProbeService {
+            inner,
+            saw_scope: self.saw_scope.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ProbeService<S> {
+    inner: S,
+    saw_scope: Arc<Mutex<bool>>,
+}
+
+impl<S> Service<Request<Body>> for ProbeService<S>
+where
+    S: Service<Request<Body>> + Clone + Send + 'static,
+    S::Future: Send,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<S::Response, S::Error>> + Send>,
+    >;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        // In scope iff the task-local is set (being set at all means
+        // RecordRequestIdLayer wrapped us).
+        let in_scope = CURRENT_REQUEST_ID.try_with(|_| ()).is_ok();
+        *self.saw_scope.lock().unwrap() = in_scope;
+        let fut = self.inner.call(req);
+        Box::pin(fut)
+    }
+}
+
+#[tokio::test]
+async fn global_layer_runs_inside_request_id_scope() {
+    let saw = Arc::new(Mutex::new(false));
+    let probe = ProbeLayer {
+        saw_scope: saw.clone(),
+    };
+
+    let cfg = AppConfig::default();
+    let mut builder = AppBuilder::from_config(&cfg).expect("builder");
+    builder.with_global_layer(move |router| router.layer(probe));
+    let app = builder.build().expect("build");
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/nonexistent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let _ = resp;
+    assert!(
+        *saw.lock().unwrap(),
+        "probe layer did not run inside CURRENT_REQUEST_ID scope"
+    );
+}

--- a/tests/lifecycle_order.rs
+++ b/tests/lifecycle_order.rs
@@ -71,6 +71,7 @@ async fn lifecycle_orchestration_order() {
         .start(vec![server], app.into_make_service())
         .await
         .expect("server start");
+    // Not load-bearing: event ordering is deterministic; this just gives the listener a beat before we drain.
     tokio::time::sleep(Duration::from_millis(100)).await;
     handle
         .graceful_shutdown(Some(Duration::from_millis(500)))

--- a/tests/lifecycle_order.rs
+++ b/tests/lifecycle_order.rs
@@ -1,0 +1,93 @@
+//! End-to-end test of lifecycle participant orchestration.
+//!
+//! NOTE: keep exactly ONE test in this file. `AppConfig::handle()` installs a
+//! process-global tracing subscriber, which can only happen once per process.
+
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use uxum::{
+    AppBuilder, AppConfig, LifecycleContext, LifecycleError, LifecycleParticipant, ServerBuilder,
+};
+
+#[derive(Debug)]
+struct Recorder {
+    name: &'static str,
+    log: Arc<Mutex<Vec<String>>>,
+}
+
+impl Recorder {
+    fn record(&self, event: &str) {
+        self.log
+            .lock()
+            .unwrap()
+            .push(format!("{}:{event}", self.name));
+    }
+}
+
+#[async_trait]
+impl LifecycleParticipant for Recorder {
+    fn name(&self) -> &str {
+        self.name
+    }
+    async fn start_pre_listen(&self, _ctx: &LifecycleContext) -> Result<(), LifecycleError> {
+        self.record("start_pre_listen");
+        Ok(())
+    }
+    async fn start_post_listen(&self, _ctx: &LifecycleContext) -> Result<(), LifecycleError> {
+        self.record("start_post_listen");
+        Ok(())
+    }
+    async fn shutdown_pre_drain(&self, _ctx: &LifecycleContext) -> Result<(), LifecycleError> {
+        self.record("shutdown_pre_drain");
+        Ok(())
+    }
+    async fn shutdown_post_drain(&self, _ctx: &LifecycleContext) -> Result<(), LifecycleError> {
+        self.record("shutdown_post_drain");
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn lifecycle_orchestration_order() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut app_cfg = AppConfig::default();
+    let mut handle = app_cfg.handle().await.expect("handle init");
+    handle.register(Arc::new(Recorder {
+        name: "a",
+        log: log.clone(),
+    }));
+    handle.register(Arc::new(Recorder {
+        name: "b",
+        log: log.clone(),
+    }));
+    let app = AppBuilder::new().build().expect("app build");
+    let mut server = ServerBuilder::default();
+    server.listen = "127.0.0.1:0".into();
+    handle
+        .start(vec![server], app.into_make_service())
+        .await
+        .expect("server start");
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    handle
+        .graceful_shutdown(Some(Duration::from_millis(500)))
+        .await
+        .expect("graceful shutdown");
+    let events = log.lock().unwrap().clone();
+    assert_eq!(
+        events,
+        vec![
+            "a:start_pre_listen",
+            "b:start_pre_listen",
+            "a:start_post_listen",
+            "b:start_post_listen",
+            "b:shutdown_pre_drain",
+            "a:shutdown_pre_drain",
+            "b:shutdown_post_drain",
+            "a:shutdown_post_drain",
+        ]
+    );
+}


### PR DESCRIPTION
This PR adds:
1. lifecycle hooks via `lifecycle::LifecycleParticipant` trait. That opens ability to gracefully handle startup/shutdown of background jobs running alongside the server: tasks for asynchronously ingesting/pushing events from/to message queues, implementing custom tracing layers, etc.;
2. ability to extend health probes with foreign logic via `probes::HealthSource` trait: mostly useful for including database connection state;
3. insertion of extra tracing subscriber layers via `config::AppConfig::with_subscriber_layer()` function;
4. ability to transform the router via `app::AppBuilder::with_global_layer()` function. That's a clever way to insert custom heterogeneous Tower layers by accepting closures (which "erase" types when applying a layer) instead of typed layers themselves.

Since uxum is currently in release candidate state (v0.10.0-rc.2), I don't know what's your expected merge window, and didn't bump the version yet. Please tell me if you'd rather postpone it to 0.11.0, or setting version to v0.10.0-rc.3 is fine.